### PR TITLE
Split timer model into service+view model

### DIFF
--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -45,7 +45,7 @@
 		D6C458AF29D229230069D89B /* ClockInUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458AE29D229230069D89B /* ClockInUITests.swift */; };
 		D6C458B129D229230069D89B /* ClockInUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458B029D229230069D89B /* ClockInUITestsLaunchTests.swift */; };
 		D6C458C129D2DD4F0069D89B /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C029D2DD4E0069D89B /* HomeViewModel.swift */; };
-		D6C458C329D2DE2D0069D89B /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C229D2DE2D0069D89B /* Home.swift */; };
+		D6C458C329D2DE2D0069D89B /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C229D2DE2D0069D89B /* HomeView.swift */; };
 		D6C458C529D35EAA0069D89B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C429D35EAA0069D89B /* SettingsView.swift */; };
 		D6C458C729D36C050069D89B /* RingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C629D36C050069D89B /* RingView.swift */; };
 		D6D02FAE29EF0B13006CD0B2 /* EditSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D02FAD29EF0B13006CD0B2 /* EditSheetView.swift */; };
@@ -115,7 +115,7 @@
 		D6C458AE29D229230069D89B /* ClockInUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockInUITests.swift; sourceTree = "<group>"; };
 		D6C458B029D229230069D89B /* ClockInUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockInUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		D6C458C029D2DD4E0069D89B /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
-		D6C458C229D2DE2D0069D89B /* Home.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Home.swift; sourceTree = "<group>"; };
+		D6C458C229D2DE2D0069D89B /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		D6C458C429D35EAA0069D89B /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		D6C458C629D36C050069D89B /* RingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingView.swift; sourceTree = "<group>"; };
 		D6D02FAD29EF0B13006CD0B2 /* EditSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSheetView.swift; sourceTree = "<group>"; };
@@ -241,7 +241,7 @@
 			isa = PBXGroup;
 			children = (
 				D6C4589529D229210069D89B /* ContentView.swift */,
-				D6C458C229D2DE2D0069D89B /* Home.swift */,
+				D6C458C229D2DE2D0069D89B /* HomeView.swift */,
 				D66750E929D713C900757F17 /* HistoryView.swift */,
 				D66750EB29D71C8300757F17 /* HistoryRow.swift */,
 				D6C458C629D36C050069D89B /* RingView.swift */,
@@ -436,7 +436,7 @@
 				D6C4589629D229210069D89B /* ContentView.swift in Sources */,
 				D67332E62AADB8B1005FFE7F /* LaunchArgument.swift in Sources */,
 				D68384F929DB25DD00228491 /* SettingViewModel.swift in Sources */,
-				D6C458C329D2DE2D0069D89B /* Home.swift in Sources */,
+				D6C458C329D2DE2D0069D89B /* HomeView.swift in Sources */,
 				D6842EC029EC178000731E84 /* StatisticsView.swift in Sources */,
 				D66750EC29D71C8300757F17 /* HistoryRow.swift in Sources */,
 				D65A976D29F323A900462D8C /* K.swift in Sources */,

--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 		D6C458A529D229230069D89B /* ClockInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458A429D229230069D89B /* ClockInTests.swift */; };
 		D6C458AF29D229230069D89B /* ClockInUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458AE29D229230069D89B /* ClockInUITests.swift */; };
 		D6C458B129D229230069D89B /* ClockInUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458B029D229230069D89B /* ClockInUITestsLaunchTests.swift */; };
-		D6C458C129D2DD4F0069D89B /* TimerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C029D2DD4E0069D89B /* TimerModel.swift */; };
+		D6C458C129D2DD4F0069D89B /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C029D2DD4E0069D89B /* HomeViewModel.swift */; };
 		D6C458C329D2DE2D0069D89B /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C229D2DE2D0069D89B /* Home.swift */; };
 		D6C458C529D35EAA0069D89B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C429D35EAA0069D89B /* SettingsView.swift */; };
 		D6C458C729D36C050069D89B /* RingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C629D36C050069D89B /* RingView.swift */; };
@@ -114,7 +114,7 @@
 		D6C458AA29D229230069D89B /* ClockInUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ClockInUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6C458AE29D229230069D89B /* ClockInUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockInUITests.swift; sourceTree = "<group>"; };
 		D6C458B029D229230069D89B /* ClockInUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockInUITestsLaunchTests.swift; sourceTree = "<group>"; };
-		D6C458C029D2DD4E0069D89B /* TimerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerModel.swift; sourceTree = "<group>"; };
+		D6C458C029D2DD4E0069D89B /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		D6C458C229D2DE2D0069D89B /* Home.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Home.swift; sourceTree = "<group>"; };
 		D6C458C429D35EAA0069D89B /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		D6C458C629D36C050069D89B /* RingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingView.swift; sourceTree = "<group>"; };
@@ -256,7 +256,7 @@
 		D6C458BF29D2DD3C0069D89B /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				D6C458C029D2DD4E0069D89B /* TimerModel.swift */,
+				D6C458C029D2DD4E0069D89B /* HomeViewModel.swift */,
 				D6E2C15A29D6C31800229286 /* HistoryViewModel.swift */,
 				D68384F829DB25DD00228491 /* SettingViewModel.swift */,
 				D6842EC129EC179200731E84 /* StatisticsViewModel.swift */,
@@ -432,7 +432,7 @@
 				D6C458C529D35EAA0069D89B /* SettingsView.swift in Sources */,
 				D65FD53D29D8B259006CC34F /* PersistanceController.swift in Sources */,
 				D66750EA29D713C900757F17 /* HistoryView.swift in Sources */,
-				D6C458C129D2DD4F0069D89B /* TimerModel.swift in Sources */,
+				D6C458C129D2DD4F0069D89B /* HomeViewModel.swift in Sources */,
 				D6C4589629D229210069D89B /* ContentView.swift in Sources */,
 				D67332E62AADB8B1005FFE7F /* LaunchArgument.swift in Sources */,
 				D68384F929DB25DD00228491 /* SettingViewModel.swift in Sources */,

--- a/ClockIn/ClockInApp.swift
+++ b/ClockIn/ClockInApp.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct ClockInApp: App {
     
     @StateObject private var container = Container()
-    @StateObject var timerModel: TimerModel = .init()
     @AppStorage("colorScheme") var preferredColorScheme: String = "system"
     
     var colorScheme: ColorScheme? {
@@ -29,7 +28,6 @@ struct ClockInApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(container)
-                .environmentObject(timerModel)
                 .preferredColorScheme(colorScheme)
         }
     }

--- a/ClockIn/Model/Container.swift
+++ b/ClockIn/Model/Container.swift
@@ -11,7 +11,8 @@ class Container: ObservableObject {
     
     private(set) var dataManager: DataManager
     private(set) var payManager: PayManager
-
+    private(set) var timerProvider: Timer.Type
+    
     enum ContainerType {
         case production, test, preview
     }
@@ -37,7 +38,7 @@ class Container: ObservableObject {
             containerType = .test
         }
         
-        
+        self.timerProvider = Timer.self
         
         switch containerType {
         case .production:

--- a/ClockIn/View/ContentView.swift
+++ b/ClockIn/View/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
     
     var body: some View {
         NavigationView {
-            Home(viewModel: HomeViewModel(dataManager: container.dataManager,
+            HomeView(viewModel: HomeViewModel(dataManager: container.dataManager,
                                        timerProvider: container.timerProvider)
             )
         }

--- a/ClockIn/View/ContentView.swift
+++ b/ClockIn/View/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
     
     var body: some View {
         NavigationView {
-            Home(viewModel: TimerModel(dataManager: container.dataManager,
+            Home(viewModel: HomeViewModel(dataManager: container.dataManager,
                                        timerProvider: container.timerProvider)
             )
         }

--- a/ClockIn/View/ContentView.swift
+++ b/ClockIn/View/ContentView.swift
@@ -9,12 +9,14 @@ import SwiftUI
 
 struct ContentView: View {
     
-    @EnvironmentObject var timerModel: TimerModel
     @AppStorage(K.UserDefaultsKeys.isRunFirstTime) var isRunFirstTime: Bool = true
+    @EnvironmentObject var container: Container
     
     var body: some View {
         NavigationView {
-            Home()
+            Home(viewModel: TimerModel(dataManager: container.dataManager,
+                                       timerProvider: container.timerProvider)
+            )
         }
             .fullScreenCover(isPresented: $isRunFirstTime, onDismiss: {
                 isRunFirstTime = false
@@ -27,6 +29,6 @@ struct ContentView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
-            .environmentObject(TimerModel())
+            .environmentObject(Container())
     }
 }

--- a/ClockIn/View/Home.swift
+++ b/ClockIn/View/Home.swift
@@ -10,10 +10,10 @@ import SwiftUI
 struct Home: View {
     private typealias Identifier = ScreenIdentifier.HomeView
     @Environment(\.colorScheme) var colorScheme
-    @StateObject private var viewModel: TimerModel
+    @StateObject private var viewModel: HomeViewModel
     @EnvironmentObject private var container: Container
     
-    init(viewModel: TimerModel) {
+    init(viewModel: HomeViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
     }
     
@@ -89,7 +89,7 @@ struct Home_Previews: PreviewProvider {
         @StateObject private var container: Container = .init()
         var body: some View {
             NavigationView {
-                Home(viewModel: TimerModel(dataManager: container.dataManager, timerProvider: container.timerProvider))
+                Home(viewModel: HomeViewModel(dataManager: container.dataManager, timerProvider: container.timerProvider))
             }
             .environmentObject(Container())
         }

--- a/ClockIn/View/Home.swift
+++ b/ClockIn/View/Home.swift
@@ -10,8 +10,12 @@ import SwiftUI
 struct Home: View {
     private typealias Identifier = ScreenIdentifier.HomeView
     @Environment(\.colorScheme) var colorScheme
-    @EnvironmentObject var timer: TimerModel
+    @StateObject private var viewModel: TimerModel
     @EnvironmentObject private var container: Container
+    
+    init(viewModel: TimerModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+    }
     
     var body: some View {
             ZStack {
@@ -19,12 +23,12 @@ struct Home: View {
                 GradientFactory.build(colorScheme: colorScheme)
                 // CONTENT
                 Button(action:
-                        timer.isStarted ? timer.stopTimer : timer.startTimer) {
+                        viewModel.isStarted ? viewModel.stopTimer : viewModel.startTimer) {
                     ZStack(alignment: .center) {
                         Circle()
                             .fill(.blue.opacity(0.5))
                             .padding()
-                        Text("\(timer.timerStringValue)")
+                        Text("\(viewModel.timerStringValue)")
                             .accessibilityIdentifier(Identifier.timerLabel.rawValue)
                             .foregroundColor(.white)
                             .font(.largeTitle)
@@ -35,11 +39,11 @@ struct Home: View {
                 } // END OF BUTTON
                         .accessibilityIdentifier(Identifier.startStopButton.rawValue)
                         .padding(60)
-                if timer.isStarted {
+                if viewModel.isStarted {
                     Button {
-                        timer.isRunning.toggle()
+                        viewModel.isRunning.toggle()
                     } label: {
-                        Image(systemName: timer.isRunning ? "pause.fill" : "play.fill")
+                        Image(systemName: viewModel.isRunning ? "pause.fill" : "play.fill")
                             .resizable()
                     } // END OF BUTTON
                     .accessibilityIdentifier(Identifier.resumePauseButton.rawValue)
@@ -47,10 +51,10 @@ struct Home: View {
                     .frame(width: 50, height: 50)
                     .offset(y: 250)
                 } // END OF IF
-                RingView(progress: $timer.progress, ringColor: .primary, pointColor: colorScheme == .light ? .white : .black)
+                RingView(progress: $viewModel.progress, ringColor: .primary, pointColor: colorScheme == .light ? .white : .black)
                     .frame(width: UIScreen.main.bounds.size.width-120, height: UIScreen.main.bounds.size.width-120)
-                if timer.overtimeProgress > 0 {
-                    RingView(progress: $timer.overtimeProgress, ringColor: .green, pointColor: .white, ringWidth: 5, startigPoint: 0.023)
+                if viewModel.overtimeProgress > 0 {
+                    RingView(progress: $viewModel.overtimeProgress, ringColor: .green, pointColor: .white, ringWidth: 5, startigPoint: 0.023)
                         .frame(width: UIScreen.main.bounds.size.width-120, height: UIScreen.main.bounds.size.width-120)
                 } // END OF IF
             } // END OF ZSTACK
@@ -81,11 +85,16 @@ struct Home: View {
 } // END OF VIEW
 
 struct Home_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            Home()
+    private struct ContainerView: View {
+        @StateObject private var container: Container = .init()
+        var body: some View {
+            NavigationView {
+                Home(viewModel: TimerModel(dataManager: container.dataManager, timerProvider: container.timerProvider))
+            }
+            .environmentObject(Container())
         }
-        .environmentObject(Container())
-        .environmentObject(TimerModel())
+    }
+    static var previews: some View {
+        ContainerView()
     }
 }

--- a/ClockIn/View/HomeView.swift
+++ b/ClockIn/View/HomeView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Home: View {
+struct HomeView: View {
     private typealias Identifier = ScreenIdentifier.HomeView
     @Environment(\.colorScheme) var colorScheme
     @StateObject private var viewModel: HomeViewModel
@@ -89,7 +89,7 @@ struct Home_Previews: PreviewProvider {
         @StateObject private var container: Container = .init()
         var body: some View {
             NavigationView {
-                Home(viewModel: HomeViewModel(dataManager: container.dataManager, timerProvider: container.timerProvider))
+                HomeView(viewModel: HomeViewModel(dataManager: container.dataManager, timerProvider: container.timerProvider))
             }
             .environmentObject(Container())
         }

--- a/ClockIn/ViewModel/HomeViewModel.swift
+++ b/ClockIn/ViewModel/HomeViewModel.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-class TimerModel: NSObject, ObservableObject {
+class HomeViewModel: NSObject, ObservableObject {
     
     // Timer countdown total values pulled from user defaults
     @AppStorage(K.UserDefaultsKeys.workTimeInSeconds) var timerTotalSeconds: Int = 28800
@@ -97,7 +97,7 @@ class TimerModel: NSObject, ObservableObject {
     
 
     //MARK: TIMER START & STOP FUNCTIONS
-extension TimerModel {
+extension HomeViewModel {
 
     func startTimer()  {
         
@@ -138,7 +138,7 @@ extension TimerModel {
 }
    
     //MARK: TIMER UPDATE FUNCTIONS
-extension TimerModel {
+extension HomeViewModel {
     
     /**
      Updates the timer countdown value
@@ -223,7 +223,7 @@ extension TimerModel {
 }
 
     //MARK: DATA OPERATIONS
-extension TimerModel {
+extension HomeViewModel {
     func checkForEntry() -> Bool {
         guard let _ = dataManager.fetch(forDate: Date()) else { return false }
         return true
@@ -241,7 +241,7 @@ extension TimerModel {
 }
 
 //MARK: NOTIFICATIONS
-extension TimerModel {
+extension HomeViewModel {
     
     func checkForPermissionAndDispatch(withTrigger trigger: UNNotificationTrigger? = nil) {
         UNUserNotificationCenter.current().getNotificationSettings { settings in

--- a/ClockInTests/TimerModelTests.swift
+++ b/ClockInTests/TimerModelTests.swift
@@ -10,11 +10,11 @@ import XCTest
 
 final class TimerModelTests: XCTestCase {
     
-    var sut: TimerModel!
+    var sut: HomeViewModel!
     
     override func setUp() {
         super.setUp()
-        sut = .init(TimerModel(dataManager: DataManager.testing, timerProvider: MockTimer.self))
+        sut = .init(HomeViewModel(dataManager: DataManager.testing, timerProvider: MockTimer.self))
     }
 
     override func tearDown() {


### PR DESCRIPTION
This PR bring a little house keeping to older parts of the project. List of main changes is below: 

Remove timer model from environment 
Rename time model to HomeViewModel
Rename Home to HomeView
Add timer provider to Container

The above changes bring the missing name spaces for the components and make it more easy to read and understand what is happening, as well as unifying the approach to services and creating new view models during DI.