### PR TITLE
Separate userdefaults into service

### DIFF
--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		D61945EC29E7306B0046DE1F /* TimerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61945EB29E7306B0046DE1F /* TimerModelTests.swift */; };
 		D61945F029E735D80046DE1F /* MockTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61945EF29E735D80046DE1F /* MockTimer.swift */; };
 		D61F11312AB38F8700902D6D /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61F11302AB38F8700902D6D /* SettingsStore.swift */; };
+		D61F11342AB3A6FF00902D6D /* ColorScheme+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61F11332AB3A6FF00902D6D /* ColorScheme+Extension.swift */; };
 		D64574B029D9E6A000207168 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574AF29D9E6A000207168 /* DataManager.swift */; };
 		D64574B329D9F16900207168 /* EntryMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574B129D9F16900207168 /* EntryMO+CoreDataClass.swift */; };
 		D64574B429D9F16900207168 /* EntryMO+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574B229D9F16900207168 /* EntryMO+CoreDataProperties.swift */; };
@@ -87,6 +88,7 @@
 		D61945EB29E7306B0046DE1F /* TimerModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerModelTests.swift; sourceTree = "<group>"; };
 		D61945EF29E735D80046DE1F /* MockTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTimer.swift; sourceTree = "<group>"; };
 		D61F11302AB38F8700902D6D /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
+		D61F11332AB3A6FF00902D6D /* ColorScheme+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColorScheme+Extension.swift"; sourceTree = "<group>"; };
 		D64574AF29D9E6A000207168 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		D64574B129D9F16900207168 /* EntryMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EntryMO+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D64574B229D9F16900207168 /* EntryMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EntryMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -155,6 +157,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		D61F11322AB3A6E700902D6D /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				D61F11332AB3A6FF00902D6D /* ColorScheme+Extension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		D67332E82AAE3C1A005FFE7F /* ScreenHelpers */ = {
 			isa = PBXGroup;
 			children = (
@@ -191,6 +201,7 @@
 		D6C4589229D229210069D89B /* ClockIn */ = {
 			isa = PBXGroup;
 			children = (
+				D61F11322AB3A6E700902D6D /* Extensions */,
 				D67332E52AADB8B1005FFE7F /* LaunchArgument.swift */,
 				D6D906AF2AA12BBD004E09C9 /* Factory */,
 				D6C4589329D229210069D89B /* ClockInApp.swift */,
@@ -432,6 +443,7 @@
 				D64574B329D9F16900207168 /* EntryMO+CoreDataClass.swift in Sources */,
 				D64574B429D9F16900207168 /* EntryMO+CoreDataProperties.swift in Sources */,
 				D6D906AE2AA0BEDE004E09C9 /* ScreenIdentifier.swift in Sources */,
+				D61F11342AB3A6FF00902D6D /* ColorScheme+Extension.swift in Sources */,
 				D6C458C529D35EAA0069D89B /* SettingsView.swift in Sources */,
 				D65FD53D29D8B259006CC34F /* PersistanceController.swift in Sources */,
 				D66750EA29D713C900757F17 /* HistoryView.swift in Sources */,

--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		D610074D2AAC77F300503C28 /* EditSheetScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D610074C2AAC77F300503C28 /* EditSheetScreen.swift */; };
 		D61945EC29E7306B0046DE1F /* TimerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61945EB29E7306B0046DE1F /* TimerModelTests.swift */; };
 		D61945F029E735D80046DE1F /* MockTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61945EF29E735D80046DE1F /* MockTimer.swift */; };
+		D61F11312AB38F8700902D6D /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61F11302AB38F8700902D6D /* SettingsStore.swift */; };
 		D64574B029D9E6A000207168 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574AF29D9E6A000207168 /* DataManager.swift */; };
 		D64574B329D9F16900207168 /* EntryMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574B129D9F16900207168 /* EntryMO+CoreDataClass.swift */; };
 		D64574B429D9F16900207168 /* EntryMO+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574B229D9F16900207168 /* EntryMO+CoreDataProperties.swift */; };
@@ -85,6 +86,7 @@
 		D610074C2AAC77F300503C28 /* EditSheetScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSheetScreen.swift; sourceTree = "<group>"; };
 		D61945EB29E7306B0046DE1F /* TimerModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerModelTests.swift; sourceTree = "<group>"; };
 		D61945EF29E735D80046DE1F /* MockTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTimer.swift; sourceTree = "<group>"; };
+		D61F11302AB38F8700902D6D /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
 		D64574AF29D9E6A000207168 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		D64574B129D9F16900207168 /* EntryMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EntryMO+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D64574B229D9F16900207168 /* EntryMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EntryMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -285,6 +287,7 @@
 				D6842EC329EC62DD00731E84 /* PayManager.swift */,
 				D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */,
 				D60EB9B52AB0D7000053136A /* Container.swift */,
+				D61F11302AB38F8700902D6D /* SettingsStore.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -437,6 +440,7 @@
 				D67332E62AADB8B1005FFE7F /* LaunchArgument.swift in Sources */,
 				D68384F929DB25DD00228491 /* SettingViewModel.swift in Sources */,
 				D6C458C329D2DE2D0069D89B /* HomeView.swift in Sources */,
+				D61F11312AB38F8700902D6D /* SettingsStore.swift in Sources */,
 				D6842EC029EC178000731E84 /* StatisticsView.swift in Sources */,
 				D66750EC29D71C8300757F17 /* HistoryRow.swift in Sources */,
 				D65A976D29F323A900462D8C /* K.swift in Sources */,

--- a/ClockIn/ClockInApp.swift
+++ b/ClockIn/ClockInApp.swift
@@ -11,16 +11,14 @@ import SwiftUI
 struct ClockInApp: App {
     
     @StateObject private var container = Container()
-    @AppStorage("colorScheme") var preferredColorScheme: String = "system"
+    @AppStorage(SettingsStore.SettingKey.savedColorScheme.rawValue) var preferredColorScheme: String?
     
     var colorScheme: ColorScheme? {
         switch preferredColorScheme {
-        case "dark":
-            return ColorScheme.dark
-        case "light":
-            return ColorScheme.light
-        default:
+        case .none:
             return nil
+        case .some(let wrapped):
+            return ColorScheme.fromStringValue(wrapped)
         }
     }
     

--- a/ClockIn/Extensions/ColorScheme+Extension.swift
+++ b/ClockIn/Extensions/ColorScheme+Extension.swift
@@ -1,0 +1,34 @@
+//
+//  ColorScheme+Extension.swift
+//  ClockIn
+//
+//  Created by Tomasz Kubiak on 14/09/2023.
+//
+
+import SwiftUI
+
+extension ColorScheme {
+    
+    var rawValue: String {
+        switch self {
+        case .light:
+            return "light"
+        case .dark:
+            return "dark"
+        @unknown default:
+            fatalError()
+        }
+    }
+    
+    static func fromStringValue(_ value: String?) -> ColorScheme? {
+        guard let unwrappedValue = value else { return nil }
+        switch unwrappedValue {
+        case "dark":
+            return ColorScheme.dark
+        case "light":
+            return ColorScheme.light
+        default:
+            return nil
+        }
+    }
+}

--- a/ClockIn/Model/Container.swift
+++ b/ClockIn/Model/Container.swift
@@ -30,8 +30,8 @@ class Container: ObservableObject {
         }
         
         if CommandLine.arguments.contains(LaunchArgument.withOnboarding.rawValue) {
-            K.resetUserDefaults()
-            UserDefaults.standard.set(true, forKey: K.UserDefaultsKeys.isRunFirstTime)
+            SettingsStore.clearUserDefaults()
+            settingsStore.isRunFirstTime = true
             containerType = .test
         }
         

--- a/ClockIn/Model/Container.swift
+++ b/ClockIn/Model/Container.swift
@@ -21,8 +21,6 @@ class Container: ObservableObject {
     
     init() {
         self.timerProvider = Timer.self
-        self.settingsStore = SettingsStore()
-        
         var containerType: ContainerType = .production
         
         if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
@@ -31,8 +29,11 @@ class Container: ObservableObject {
         
         if CommandLine.arguments.contains(LaunchArgument.withOnboarding.rawValue) {
             SettingsStore.clearUserDefaults()
+            self.settingsStore = SettingsStore()
             settingsStore.isRunFirstTime = true
             containerType = .test
+        } else {
+            self.settingsStore = SettingsStore()
         }
         
         if CommandLine.arguments.contains(LaunchArgument.inMemoryPresistenStore.rawValue) {

--- a/ClockIn/Model/Container.swift
+++ b/ClockIn/Model/Container.swift
@@ -13,7 +13,7 @@ class Container: ObservableObject {
     private(set) var dataManager: DataManager
     private(set) var payManager: PayManager
     private(set) var timerProvider: Timer.Type
-    var settingsStore: SettingsStore
+    private(set) var settingsStore: SettingsStore
     
     enum ContainerType {
         case production, test, preview
@@ -54,8 +54,5 @@ class Container: ObservableObject {
             self.dataManager = .preview
             self.payManager = PayManager(dataManager: .preview)
         }
-        settingsStore.objectWillChange.sink { _ in
-            self.objectWillChange.send()
-        }.store(in: &subscriptions)
     }
 }

--- a/ClockIn/Model/SettingsStore.swift
+++ b/ClockIn/Model/SettingsStore.swift
@@ -6,9 +6,12 @@
 //
 
 import SwiftUI
+import Combine
 
 final class SettingsStore: ObservableObject {
-    // setting keys - not sure if enum here is what i need for keys
+    private var subscriptions = Set<AnyCancellable>()
+    private let defaults = UserDefaults.standard
+    
     enum SettingKey: String, CaseIterable {
         case isRunFirstTime
         case isLoggingOvertime
@@ -20,55 +23,14 @@ final class SettingsStore: ObservableObject {
         case savedColorScheme
     }
     
-    private let defaults = UserDefaults.standard
-    
-    @Published var isRunFirstTime: Bool {
-        didSet {
-            updateSetting(setting: .isRunFirstTime, value: isRunFirstTime)
-        }
-    }
-    @Published var isLoggingOvertime: Bool {
-        didSet {
-            updateSetting(setting: .isLoggingOvertime, value: isLoggingOvertime)
-        }
-    }
-    @Published var isCalculatingNetPay: Bool {
-        didSet {
-            updateSetting(setting: .isCalculatingNetPay, value: isCalculatingNetPay)
-        }
-    }
-    
-    @Published var isSendingNotification: Bool {
-        didSet {
-            updateSetting(setting: .isSendingNotifications, value: isSendingNotification)
-        }
-    }
-    
-    @Published var maximumOvertimeAllowedInSeconds: Int {
-        didSet {
-            updateSetting(setting: .maximumOvertimeAllowedInSeconds, value: maximumOvertimeAllowedInSeconds)
-        }
-    }
-    
-    @Published var workTimeInSeconds: Int {
-        didSet {
-            updateSetting(setting: .workTimeInSeconds, value: workTimeInSeconds)
-        }
-    }
-    
-    @Published var grossPayPerMonth: Int {
-        didSet {
-            updateSetting(setting: .grossPayPerMonth, value: grossPayPerMonth)
-        }
-    }
-    
-    @Published var savedColorScheme: ColorScheme? {
-        didSet {
-            if let rawValue = savedColorScheme?.rawValue {
-                updateSetting(setting: .savedColorScheme, value: rawValue)
-            }
-        }
-    }
+    @Published var isRunFirstTime: Bool
+    @Published var isLoggingOvertime: Bool
+    @Published var isCalculatingNetPay: Bool
+    @Published var isSendingNotification: Bool
+    @Published var maximumOvertimeAllowedInSeconds: Int
+    @Published var workTimeInSeconds: Int
+    @Published var grossPayPerMonth: Int
+    @Published var savedColorScheme: ColorScheme?
     
     init() {
         if let value = defaults.value(forKey: SettingKey.isRunFirstTime.rawValue) as? Bool {
@@ -83,6 +45,78 @@ final class SettingsStore: ObservableObject {
         self.workTimeInSeconds = defaults.integer(forKey: SettingKey.workTimeInSeconds.rawValue)
         self.grossPayPerMonth = defaults.integer(forKey: SettingKey.grossPayPerMonth.rawValue)
         self.savedColorScheme = ColorScheme.fromStringValue(defaults.string(forKey: SettingKey.savedColorScheme.rawValue))
+        self.setUpSubscribersSavingToUserDefaults()
+    }
+    
+    func setUpSubscribersSavingToUserDefaults() {
+        $isRunFirstTime
+            .removeDuplicates()
+            .sink { [weak self] value in
+                guard let self else { return }
+                self.updateSetting(setting: .isRunFirstTime, value: value)
+            }.store(in: &subscriptions)
+        $isLoggingOvertime
+            .removeDuplicates()
+            .sink { [weak self] value in
+                guard let self else { return }
+                self.updateSetting(setting: .isLoggingOvertime, value: value)
+            }.store(in: &subscriptions)
+        $isCalculatingNetPay
+            .removeDuplicates()
+            .sink { [weak self] value in
+                guard let self else { return }
+                self.updateSetting(setting: .isCalculatingNetPay, value: value)
+            }.store(in: &subscriptions)
+        $isSendingNotification
+            .removeDuplicates()
+            .sink { [weak self] value in
+                guard let self else { return }
+                self.updateSetting(setting: .isSendingNotifications, value: value)
+            }.store(in: &subscriptions)
+     $maximumOvertimeAllowedInSeconds
+            .removeDuplicates()
+            .sink { [weak self] value in
+                guard let self else { return }
+                self.updateSetting(setting: .maximumOvertimeAllowedInSeconds, value: value)
+            }.store(in: &subscriptions)
+        $workTimeInSeconds
+            .removeDuplicates()
+            .sink { [weak self] value in
+                guard let self else { return }
+                self.updateSetting(setting: .workTimeInSeconds, value: value)
+            }.store(in: &subscriptions)
+        $grossPayPerMonth
+            .removeDuplicates()
+            .sink { [weak self] value in
+                guard let self else { return }
+                self.updateSetting(setting: .grossPayPerMonth, value: value)
+            }.store(in: &subscriptions)
+        $savedColorScheme
+            .removeDuplicates()
+            .sink { [weak self] value  in
+                guard let self else { return }
+                self.updateSetting(setting: .savedColorScheme, value: value)
+            }.store(in: &subscriptions)
+    }
+    
+    func clearStore() {
+        subscriptions.removeAll()
+        for key in SettingKey.allCases {
+            UserDefaults.standard.removeObject(forKey: key.rawValue)
+        }
+        if let value = defaults.value(forKey: SettingKey.isRunFirstTime.rawValue) as? Bool {
+            self.isRunFirstTime = value
+        } else {
+            self.isRunFirstTime = true
+        }
+        isLoggingOvertime = defaults.bool(forKey: SettingKey.isLoggingOvertime.rawValue)
+        isCalculatingNetPay = defaults.bool(forKey: SettingKey.isCalculatingNetPay.rawValue)
+        isSendingNotification = defaults.bool(forKey: SettingKey.isSendingNotifications.rawValue)
+        maximumOvertimeAllowedInSeconds = defaults.integer(forKey: SettingKey.maximumOvertimeAllowedInSeconds.rawValue)
+        workTimeInSeconds = defaults.integer(forKey: SettingKey.workTimeInSeconds.rawValue)
+        grossPayPerMonth = defaults.integer(forKey: SettingKey.grossPayPerMonth.rawValue)
+        savedColorScheme = ColorScheme.fromStringValue(defaults.string(forKey: SettingKey.savedColorScheme.rawValue))
+        setUpSubscribersSavingToUserDefaults()
     }
     
     static func clearUserDefaults() {

--- a/ClockIn/Model/SettingsStore.swift
+++ b/ClockIn/Model/SettingsStore.swift
@@ -1,0 +1,91 @@
+//
+//  SettingsStore.swift
+//  ClockIn
+//
+//  Created by Tomasz Kubiak on 14/09/2023.
+//
+
+import Foundation
+
+final class SettingsStore: ObservableObject {
+    // setting keys - not sure if enum here is what i need for keys
+    enum SettingKey: String, CaseIterable {
+        case isRunFirstTime
+        case isLoggingOvertime
+        case isCalculatingNetPay
+        case isSendingNotifications
+        case maximumOvertimeAllowedInSeconds
+        case workTimeInSeconds
+        case grossPayPerMonth
+        case savedColorScheme
+    }
+    
+    private let defaults = UserDefaults.standard
+    
+    var isRunFirstTime: Bool {
+        didSet {
+            updateSetting(setting: .isRunFirstTime, value: isRunFirstTime)
+        }
+    }
+    var isLoggingOvertime: Bool {
+        didSet {
+            updateSetting(setting: .isLoggingOvertime, value: isLoggingOvertime)
+        }
+    }
+    var isCalculatingNetPay: Bool {
+        didSet {
+            updateSetting(setting: .isCalculatingNetPay, value: isCalculatingNetPay)
+        }
+    }
+    
+    var isSendingNotification: Bool {
+        didSet {
+            updateSetting(setting: .isSendingNotifications, value: isSendingNotification)
+        }
+    }
+    
+    var maximumOvertimeAllowedInSeconds: Int {
+        didSet {
+            updateSetting(setting: .maximumOvertimeAllowedInSeconds, value: maximumOvertimeAllowedInSeconds)
+        }
+    }
+    
+    var workTimeInSeconds: Int {
+        didSet {
+            updateSetting(setting: .workTimeInSeconds, value: workTimeInSeconds)
+        }
+    }
+    
+    var grossPayPerMonth: Int {
+        didSet {
+            updateSetting(setting: .grossPayPerMonth, value: grossPayPerMonth)
+        }
+    }
+    
+    var savedColorScheme: K.ColorScheme {
+        didSet {
+            updateSetting(setting: .savedColorScheme, value: savedColorScheme.rawValue)
+        }
+    }
+    
+    init() {
+        self.isRunFirstTime = defaults.bool(forKey: SettingKey.isRunFirstTime.rawValue)
+        self.isLoggingOvertime = defaults.bool(forKey: SettingKey.isLoggingOvertime.rawValue)
+        self.isCalculatingNetPay = defaults.bool(forKey: SettingKey.isCalculatingNetPay.rawValue)
+        self.isSendingNotification = defaults.bool(forKey: SettingKey.isSendingNotifications.rawValue)
+        self.maximumOvertimeAllowedInSeconds = defaults.integer(forKey: SettingKey.maximumOvertimeAllowedInSeconds.rawValue)
+        self.workTimeInSeconds = defaults.integer(forKey: SettingKey.workTimeInSeconds.rawValue)
+        self.grossPayPerMonth = defaults.integer(forKey: SettingKey.grossPayPerMonth.rawValue)
+        self.savedColorScheme = K.ColorScheme(rawValue: defaults.string(forKey: SettingKey.savedColorScheme.rawValue) ?? "system") ?? .system
+    }
+    
+    static func clearUserDefaults() {
+        for key in SettingKey.allCases {
+            UserDefaults.standard.removeObject(forKey: key.rawValue)
+        }
+    }
+    
+    private func updateSetting<T>(setting: SettingKey, value: T) {
+        defaults.set(value, forKey: setting.rawValue)
+    }
+}

--- a/ClockIn/Model/SettingsStore.swift
+++ b/ClockIn/Model/SettingsStore.swift
@@ -50,48 +50,56 @@ final class SettingsStore: ObservableObject {
     
     func setUpSubscribersSavingToUserDefaults() {
         $isRunFirstTime
+            .dropFirst()
             .removeDuplicates()
             .sink { [weak self] value in
                 guard let self else { return }
                 self.updateSetting(setting: .isRunFirstTime, value: value)
             }.store(in: &subscriptions)
         $isLoggingOvertime
+            .dropFirst()
             .removeDuplicates()
             .sink { [weak self] value in
                 guard let self else { return }
                 self.updateSetting(setting: .isLoggingOvertime, value: value)
             }.store(in: &subscriptions)
         $isCalculatingNetPay
+            .dropFirst()
             .removeDuplicates()
             .sink { [weak self] value in
                 guard let self else { return }
                 self.updateSetting(setting: .isCalculatingNetPay, value: value)
             }.store(in: &subscriptions)
         $isSendingNotification
+            .dropFirst()
             .removeDuplicates()
             .sink { [weak self] value in
                 guard let self else { return }
                 self.updateSetting(setting: .isSendingNotifications, value: value)
             }.store(in: &subscriptions)
      $maximumOvertimeAllowedInSeconds
+            .dropFirst()
             .removeDuplicates()
             .sink { [weak self] value in
                 guard let self else { return }
                 self.updateSetting(setting: .maximumOvertimeAllowedInSeconds, value: value)
             }.store(in: &subscriptions)
         $workTimeInSeconds
+            .dropFirst()
             .removeDuplicates()
             .sink { [weak self] value in
                 guard let self else { return }
                 self.updateSetting(setting: .workTimeInSeconds, value: value)
             }.store(in: &subscriptions)
         $grossPayPerMonth
+            .dropFirst()
             .removeDuplicates()
             .sink { [weak self] value in
                 guard let self else { return }
                 self.updateSetting(setting: .grossPayPerMonth, value: value)
             }.store(in: &subscriptions)
         $savedColorScheme
+            .dropFirst()
             .removeDuplicates()
             .sink { [weak self] value  in
                 guard let self else { return }

--- a/ClockIn/Model/SettingsStore.swift
+++ b/ClockIn/Model/SettingsStore.swift
@@ -5,7 +5,7 @@
 //  Created by Tomasz Kubiak on 14/09/2023.
 //
 
-import Foundation
+import SwiftUI
 
 final class SettingsStore: ObservableObject {
     // setting keys - not sure if enum here is what i need for keys
@@ -22,61 +22,67 @@ final class SettingsStore: ObservableObject {
     
     private let defaults = UserDefaults.standard
     
-    var isRunFirstTime: Bool {
+    @Published var isRunFirstTime: Bool {
         didSet {
             updateSetting(setting: .isRunFirstTime, value: isRunFirstTime)
         }
     }
-    var isLoggingOvertime: Bool {
+    @Published var isLoggingOvertime: Bool {
         didSet {
             updateSetting(setting: .isLoggingOvertime, value: isLoggingOvertime)
         }
     }
-    var isCalculatingNetPay: Bool {
+    @Published var isCalculatingNetPay: Bool {
         didSet {
             updateSetting(setting: .isCalculatingNetPay, value: isCalculatingNetPay)
         }
     }
     
-    var isSendingNotification: Bool {
+    @Published var isSendingNotification: Bool {
         didSet {
             updateSetting(setting: .isSendingNotifications, value: isSendingNotification)
         }
     }
     
-    var maximumOvertimeAllowedInSeconds: Int {
+    @Published var maximumOvertimeAllowedInSeconds: Int {
         didSet {
             updateSetting(setting: .maximumOvertimeAllowedInSeconds, value: maximumOvertimeAllowedInSeconds)
         }
     }
     
-    var workTimeInSeconds: Int {
+    @Published var workTimeInSeconds: Int {
         didSet {
             updateSetting(setting: .workTimeInSeconds, value: workTimeInSeconds)
         }
     }
     
-    var grossPayPerMonth: Int {
+    @Published var grossPayPerMonth: Int {
         didSet {
             updateSetting(setting: .grossPayPerMonth, value: grossPayPerMonth)
         }
     }
     
-    var savedColorScheme: K.ColorScheme {
+    @Published var savedColorScheme: ColorScheme? {
         didSet {
-            updateSetting(setting: .savedColorScheme, value: savedColorScheme.rawValue)
+            if let rawValue = savedColorScheme?.rawValue {
+                updateSetting(setting: .savedColorScheme, value: rawValue)
+            }
         }
     }
     
     init() {
-        self.isRunFirstTime = defaults.bool(forKey: SettingKey.isRunFirstTime.rawValue)
+        if let value = defaults.value(forKey: SettingKey.isRunFirstTime.rawValue) as? Bool {
+            self.isRunFirstTime = value
+        } else {
+            self.isRunFirstTime = true
+        }
         self.isLoggingOvertime = defaults.bool(forKey: SettingKey.isLoggingOvertime.rawValue)
         self.isCalculatingNetPay = defaults.bool(forKey: SettingKey.isCalculatingNetPay.rawValue)
         self.isSendingNotification = defaults.bool(forKey: SettingKey.isSendingNotifications.rawValue)
         self.maximumOvertimeAllowedInSeconds = defaults.integer(forKey: SettingKey.maximumOvertimeAllowedInSeconds.rawValue)
         self.workTimeInSeconds = defaults.integer(forKey: SettingKey.workTimeInSeconds.rawValue)
         self.grossPayPerMonth = defaults.integer(forKey: SettingKey.grossPayPerMonth.rawValue)
-        self.savedColorScheme = K.ColorScheme(rawValue: defaults.string(forKey: SettingKey.savedColorScheme.rawValue) ?? "system") ?? .system
+        self.savedColorScheme = ColorScheme.fromStringValue(defaults.string(forKey: SettingKey.savedColorScheme.rawValue))
     }
     
     static func clearUserDefaults() {

--- a/ClockIn/View/ContentView.swift
+++ b/ClockIn/View/ContentView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct ContentView: View {
     
-    @AppStorage(K.UserDefaultsKeys.isRunFirstTime) var isRunFirstTime: Bool = true
     @EnvironmentObject var container: Container
     
     var body: some View {
@@ -18,8 +17,8 @@ struct ContentView: View {
                                        timerProvider: container.timerProvider)
             )
         }
-            .fullScreenCover(isPresented: $isRunFirstTime, onDismiss: {
-                isRunFirstTime = false
+        .fullScreenCover(isPresented: $container.settingsStore.isRunFirstTime, onDismiss: {
+            container.settingsStore.isRunFirstTime = false
             }) {
                 OnboardingView()
             }

--- a/ClockIn/View/ContentView.swift
+++ b/ClockIn/View/ContentView.swift
@@ -21,7 +21,7 @@ struct ContentView: View {
         .fullScreenCover(isPresented: $isRunFirstTime, onDismiss: {
             isRunFirstTime = false
             }) {
-                OnboardingView()
+                OnboardingView(viewModel: OnboardingViewModel(settingsStore: container.settingsStore))
             }
     }
 }

--- a/ClockIn/View/ContentView.swift
+++ b/ClockIn/View/ContentView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ContentView: View {
     
     @EnvironmentObject var container: Container
+    @AppStorage(SettingsStore.SettingKey.isRunFirstTime.rawValue) var isRunFirstTime: Bool = true 
     
     var body: some View {
         NavigationView {
@@ -17,8 +18,8 @@ struct ContentView: View {
                                        timerProvider: container.timerProvider)
             )
         }
-        .fullScreenCover(isPresented: $container.settingsStore.isRunFirstTime, onDismiss: {
-            container.settingsStore.isRunFirstTime = false
+        .fullScreenCover(isPresented: $isRunFirstTime, onDismiss: {
+            isRunFirstTime = false
             }) {
                 OnboardingView()
             }

--- a/ClockIn/View/HomeView.swift
+++ b/ClockIn/View/HomeView.swift
@@ -74,7 +74,10 @@ struct HomeView: View {
                 } // END OF TOOLBAR ITEM
                 ToolbarItem(placement: .navigationBarTrailing) {
                     NavigationLink {
-                        SettingsView(viewModel: SettingsViewModel(dataManger: container.dataManager))
+                        SettingsView(viewModel:
+                                        SettingsViewModel(
+                                            dataManger: container.dataManager,
+                                            settingsStore: container.settingsStore))
                     } label: {
                         Text("Settings")
                     } // END OF NAV LINK

--- a/ClockIn/View/OnboardingView.swift
+++ b/ClockIn/View/OnboardingView.swift
@@ -13,8 +13,11 @@ struct OnboardingView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) var dismiss
     
-    @StateObject var viewModel = OnboardingViewModel()
+    @StateObject var viewModel: OnboardingViewModel
     
+    init(viewModel: OnboardingViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+    }
     //Onboarding stages:
     /*
      0 - Logo and welcome message
@@ -168,16 +171,17 @@ extension OnboardingView {
                         .offset(y: 20)
                         .foregroundColor(.primary)
                 }
-            if !viewModel.isLoggingOvertime {
+            if !viewModel.settingsStore.isLoggingOvertime {
                 Text("Let ClockIn know wheter you want to measure overtime")
                     .multilineTextAlignment(.center)
             }
-            Toggle("Keep logging overtime", isOn: $viewModel.isLoggingOvertime)
+            // should start as false is nto starting as false?
+            Toggle("Keep logging overtime", isOn: $viewModel.settingsStore.isLoggingOvertime)
                 .accessibilityIdentifier(Identifier.Toggles.overtime.rawValue)
                 .padding()
                 .background()
                 .cornerRadius(20)
-            if viewModel.isLoggingOvertime {
+            if viewModel.settingsStore.isLoggingOvertime {
                 Text("Let the app know what is the maximum overtime you can work for.")
                     .multilineTextAlignment(.center)
                 HStack {
@@ -225,7 +229,7 @@ extension OnboardingView {
             Text("Do you want to allow ClockIn to send you notifications when the work time is finished?")
                 .multilineTextAlignment(.center)
             
-            Toggle("Send notifications on finish", isOn: $viewModel.isSendingNotifications)
+            Toggle("Send notifications on finish", isOn: $viewModel.settingsStore.isSendingNotification)
                 .accessibilityIdentifier(Identifier.Toggles.notifications.rawValue)
                 .padding()
                 .background()
@@ -263,7 +267,7 @@ extension OnboardingView {
             
             Text("Do you want to allow ClockIn to calculate your net salary based on Polish tax law?")
                 .multilineTextAlignment(.center)
-            Toggle("Calculate net salary", isOn: $viewModel.netPayAvaliable)
+            Toggle("Calculate net salary", isOn: $viewModel.settingsStore.isCalculatingNetPay)
                 .accessibilityIdentifier(Identifier.Toggles.calculateNetSalary.rawValue)
                 .padding()
                 .background()
@@ -359,6 +363,6 @@ extension OnboardingView {
 
 struct OnboardingView_Previews: PreviewProvider {
     static var previews: some View {
-        OnboardingView()
+        OnboardingView(viewModel: OnboardingViewModel(settingsStore: SettingsStore()))
     }
 }

--- a/ClockIn/View/OnboardingView.swift
+++ b/ClockIn/View/OnboardingView.swift
@@ -14,59 +14,70 @@ struct OnboardingView: View {
     @Environment(\.dismiss) var dismiss
     
     @StateObject var viewModel = OnboardingViewModel()
-   
+    
+    //Onboarding stages:
+    /*
+     0 - Logo and welcome message
+     1 - Set the work time
+     2 - Ask if doing overtime and set maximum overtime
+     3 - Ask to send notifications on finish
+     4 - Ask user for salary and if to calculate net salary (after taxes)
+     5 - Inform setup complete, allows to Finish onboarding
+     */
+    @State var onboardingStage: Int = 0
+    
     let tansition: AnyTransition = .asymmetric(
         insertion: .move(edge: .trailing),
         removal: .move(edge: .leading))
     
     var body: some View {
         
-            ZStack{
-                //BACKGROUND
-                GradientFactory.build(colorScheme: colorScheme)
-                //CONTENT
-                ZStack {
-                    switch viewModel.onboardingStage {
-                    case 0:
-                        stage0Screen
-                    case 1:
-                        stage1Screen
-                    case 2:
-                        stage2Screen
-                    case 3:
-                        stage3Screen
-                    case 4:
-                        stage4Screen
-                    case 5:
-                        stage5Screen
-                    default:
-                        Rectangle()
-                            .foregroundColor(.accentColor)
-                            .cornerRadius(10)
-                            .frame(width: 200, height: 200)
-                            .overlay {
-                                Text("END OF ON \n BOARDING")
-                                    .font(.largeTitle)
-                                    .fontWeight(.heavy)
-                                    .foregroundColor(.white)
-                                    .multilineTextAlignment(.center)
-                            }
-                        
-                    }
-                }
-                
-                VStack {
-                    if viewModel.onboardingStage != 0 {
-                        HStack {
-                            topButton
-                            Spacer()
+        ZStack{
+            //BACKGROUND
+            GradientFactory.build(colorScheme: colorScheme)
+            //CONTENT
+            ZStack {
+                switch onboardingStage {
+                case 0:
+                    stage0Screen
+                case 1:
+                    stage1Screen
+                case 2:
+                    stage2Screen
+                case 3:
+                    stage3Screen
+                case 4:
+                    stage4Screen
+                case 5:
+                    stage5Screen
+                default:
+                    Rectangle()
+                        .foregroundColor(.accentColor)
+                        .cornerRadius(10)
+                        .frame(width: 200, height: 200)
+                        .overlay {
+                            Text("END OF ON \n BOARDING")
+                                .font(.largeTitle)
+                                .fontWeight(.heavy)
+                                .foregroundColor(.white)
+                                .multilineTextAlignment(.center)
                         }
-                    }
-                    Spacer()
-                    bottomButton
+                    
                 }
-                .padding(30)
             }
+            
+            VStack {
+                if onboardingStage != 0 {
+                    HStack {
+                        topButton
+                        Spacer()
+                    }
+                }
+                Spacer()
+                bottomButton
+            }
+            .padding(30)
+        }
     }
 }
 extension OnboardingView {
@@ -223,7 +234,7 @@ extension OnboardingView {
         }
         .padding(30)
     }
-
+    
     private var stage4Screen: some View {
         VStack(spacing: 40) {
             
@@ -274,28 +285,28 @@ extension OnboardingView {
             
             //This section is still in works until in-app tutorial is developed
             /*
-            Text("To enter a short tutorial on how to use the app and its functions click the tour button. Alternatively, if you are a person that assembles the IKEA furniture without looking at the instructions click the finish button")
-                .multilineTextAlignment(.center)
-            
-            
-            Text("Finish!")
-                .font(.headline)
-                .foregroundColor(.accentColor)
-                .frame(height: 55)
-                .frame(maxWidth: .infinity)
-                .background(Color.primary.colorInvert())
-                .cornerRadius(10)
-                .overlay {
-                    HStack {
-                        Spacer()
-                        Image(systemName: "bicycle")
-                        Image(systemName: "figure.walk")
-                    }
-                    .padding()
-                }
-                .onTapGesture {
-                    dismiss()
-                }
+             Text("To enter a short tutorial on how to use the app and its functions click the tour button. Alternatively, if you are a person that assembles the IKEA furniture without looking at the instructions click the finish button")
+             .multilineTextAlignment(.center)
+             
+             
+             Text("Finish!")
+             .font(.headline)
+             .foregroundColor(.accentColor)
+             .frame(height: 55)
+             .frame(maxWidth: .infinity)
+             .background(Color.primary.colorInvert())
+             .cornerRadius(10)
+             .overlay {
+             HStack {
+             Spacer()
+             Image(systemName: "bicycle")
+             Image(systemName: "figure.walk")
+             }
+             .padding()
+             }
+             .onTapGesture {
+             dismiss()
+             }
              */
         }
         .padding(30)
@@ -307,14 +318,14 @@ extension OnboardingView {
             .foregroundColor(.accentColor)
             .onTapGesture {
                 withAnimation(.spring()) {
-                    viewModel.onboardingStage -= 1
+                    onboardingStage -= 1
                 }
             }
     }
     
     private var bottomButton: some View {
-        Text(viewModel.onboardingStage == 0 ? "Let's start!" :
-                viewModel.onboardingStage == 5 ? "Finish set up!" : "Next")
+        Text(onboardingStage == 0 ? "Let's start!" :
+                onboardingStage == 5 ? "Finish set up!" : "Next")
         .accessibilityIdentifier(Identifier.Buttons.advanceStage.rawValue)
         .font(.headline)
         .foregroundColor(.blue)
@@ -336,10 +347,10 @@ extension OnboardingView {
         .cornerRadius(10)
         .onTapGesture {
             withAnimation(.spring()) {
-                if viewModel.onboardingStage == 5 {
+                if onboardingStage == 5 {
                     dismiss()
                 } else {
-                    viewModel.onboardingStage += 1
+                    onboardingStage += 1
                 }
             }
         }

--- a/ClockIn/View/SettingsView.swift
+++ b/ClockIn/View/SettingsView.swift
@@ -43,7 +43,7 @@ struct SettingsView: View {
                         timePickers
                     } // END OF IF
                     
-                    Toggle(isOn: $viewModel.isSendingNotifications) {
+                    Toggle(isOn: $viewModel.settingsStore.isSendingNotification) {
                         Text("Send notification on finish")
                     } // END OF TOGGLE
                     .accessibilityIdentifier(Identifier.ToggableCells.sendNotificationsOnFinish.rawValue)
@@ -53,7 +53,7 @@ struct SettingsView: View {
                 } // END OF SECTION
                 Section {
                     
-                    Toggle(isOn: $viewModel.isLoggingOverTime) {
+                    Toggle(isOn: $viewModel.settingsStore.isLoggingOvertime) {
                         Text("Keep loging overtime")
                     }
                     .accessibilityIdentifier(Identifier.ToggableCells.keepLoggingOvertime.rawValue)
@@ -87,7 +87,7 @@ struct SettingsView: View {
                             .keyboardType(.numberPad)
                         Text("PLN")
                     }
-                    Toggle("Calculate net pay", isOn: $viewModel.calculateNetPaycheck)
+                    Toggle("Calculate net pay", isOn: $viewModel.settingsStore.isCalculatingNetPay)
                         .accessibilityIdentifier(Identifier.ToggableCells.calculateNetPay.rawValue)
                 } header: {
                     Text("Paycheck calculation")
@@ -123,15 +123,15 @@ struct SettingsView: View {
                 Section {
                     VStack{
                         Text("Color scheme")
-                        Picker("appearance", selection: $viewModel.preferredColorScheme) {
+                        Picker("appearance", selection: $viewModel.settingsStore.savedColorScheme) {
                             Text("System")
-                                .tag("system")
+                                .tag(nil as ColorScheme?)
                                 .accessibilityIdentifier(Identifier.SegmentedControlButtons.system.rawValue)
                             Text("Dark")
-                                .tag("dark")
+                                .tag(ColorScheme.dark)
                                 .accessibilityIdentifier(Identifier.SegmentedControlButtons.dark.rawValue)
                             Text("Light")
-                                .tag("light")
+                                .tag(ColorScheme.light)
                                 .accessibilityIdentifier(Identifier.SegmentedControlButtons.light.rawValue)
                         } // END OF PICKER
                         .accessibilityIdentifier(Identifier.Pickers.appearancePicker.rawValue)

--- a/ClockIn/View/SettingsView.swift
+++ b/ClockIn/View/SettingsView.swift
@@ -11,6 +11,8 @@ struct SettingsView: View {
     private typealias Identifier = ScreenIdentifier.SettingsView
     @Environment(\.colorScheme) var colorScheme
     @StateObject private var viewModel: SettingsViewModel
+    @State private var isShowingWorkTimeEditor: Bool = false
+    @State private var isShowingOvertimeEditor: Bool = false
     
     init(viewModel: SettingsViewModel) {
         self._viewModel = StateObject.init(wrappedValue: viewModel)
@@ -27,17 +29,17 @@ struct SettingsView: View {
                     HStack {
                         Text("Set timer length")
                         Spacer()
-                        Image(systemName: viewModel.isShowingWorkTimeEditor ? "chevron.up" : "chevron.down")
+                        Image(systemName: isShowingWorkTimeEditor ? "chevron.up" : "chevron.down")
                     } // END OF HSTACK
                     .accessibilityIdentifier(Identifier.ExpandableCells.setTimerLength.rawValue)
                     .contentShape(Rectangle())
                     .onTapGesture {
                         withAnimation(.spring()) {
-                            viewModel.isShowingWorkTimeEditor.toggle()
+                            isShowingWorkTimeEditor.toggle()
                         }
                     } // END OF TAP GESTURE
                     
-                    if viewModel.isShowingWorkTimeEditor {
+                    if isShowingWorkTimeEditor {
                         timePickers
                     } // END OF IF
                     
@@ -59,17 +61,17 @@ struct SettingsView: View {
                     HStack {
                         Text("Maximum overtime allowed")
                         Spacer()
-                        Image(systemName: viewModel.isShowingOverTimeEditor ? "chevron.up" : "chevron.down")
+                        Image(systemName: isShowingOvertimeEditor ? "chevron.up" : "chevron.down")
                     } // END OF HSTACK
                     .accessibilityIdentifier(Identifier.ExpandableCells.setOvertimeLength.rawValue)
                     .contentShape(Rectangle())
                     .onTapGesture {
                         withAnimation(.spring()) {
-                            viewModel.isShowingOverTimeEditor.toggle()
+                            isShowingOvertimeEditor.toggle()
                         }
                     } // END OF TAP GESTURE
                     
-                    if viewModel.isShowingOverTimeEditor {
+                    if isShowingOvertimeEditor {
                         overTimePickers
                     }
                 } header: {

--- a/ClockIn/View/SettingsView.swift
+++ b/ClockIn/View/SettingsView.swift
@@ -12,7 +12,7 @@ struct SettingsView: View {
     @Environment(\.colorScheme) var colorScheme
     @StateObject private var viewModel: SettingsViewModel
     
-    init(viewModel: SettingsViewModel = SettingsViewModel(dataManger: .shared)) {
+    init(viewModel: SettingsViewModel) {
         self._viewModel = StateObject.init(wrappedValue: viewModel)
     }
     
@@ -197,10 +197,16 @@ struct SettingsView: View {
 }
 
 struct SettingsView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            SettingsView()
+    private struct ContainerView: View {
+        @StateObject private var container = Container()
+        var body: some View {
+            NavigationView {
+                SettingsView(viewModel: SettingsViewModel(dataManger: container.dataManager, settingsStore: container.settingsStore))
+            }
         }
+    }
+    static var previews: some View {
+        ContainerView()
     }
         
 }

--- a/ClockIn/View/SettingsView.swift
+++ b/ClockIn/View/SettingsView.swift
@@ -12,7 +12,7 @@ struct SettingsView: View {
     @Environment(\.colorScheme) var colorScheme
     @StateObject private var viewModel: SettingsViewModel
     
-    init(viewModel: SettingsViewModel = SettingsViewModel()) {
+    init(viewModel: SettingsViewModel = SettingsViewModel(dataManger: .shared)) {
         self._viewModel = StateObject.init(wrappedValue: viewModel)
     }
     

--- a/ClockIn/ViewModel/OnboardingViewModel.swift
+++ b/ClockIn/ViewModel/OnboardingViewModel.swift
@@ -10,21 +10,10 @@ import SwiftUI
 
 class OnboardingViewModel: ObservableObject {
     
-    //Onboarding stages:
-    /*
-     0 - Logo and welcome message
-     1 - Set the work time
-     2 - Ask if doing overtime and set maximum overtime
-     3 - Ask to send notifications on finish
-     4 - Ask user for salary and if to calculate net salary (after taxes)
-     5 - Inform setup complete, allows to Finish onboarding
-     */
-    
-    @Published var onboardingStage: Int = 0
-    
+    @Published private var settingsStore: SettingsStore
     @Published var isLoggingOvertime: Bool {
         didSet {
-            UserDefaults.standard.set(isLoggingOvertime, forKey: K.UserDefaultsKeys.isLoggingOvertime)
+            UserDefaults.standard.set(isLoggingOvertime, forKey: SettingsStore.SettingKey.isLoggingOvertime.rawValue)//K.UserDefaultsKeys.isLoggingOvertime)
         }
     }
     
@@ -93,12 +82,12 @@ class OnboardingViewModel: ObservableObject {
         }
     }
     
-    
-    init() {
+    init(settingsStore: SettingsStore) {
+        self.settingsStore = settingsStore
         let userDef = UserDefaults.standard
         self.workTimeInSeconds = userDef.integer(forKey: K.UserDefaultsKeys.workTimeInSeconds)
         self.maxOvertimeAllowedinSeconds = userDef.integer(forKey: K.UserDefaultsKeys.maximumOverTimeAllowedInSeconds)
-        self.isLoggingOvertime = userDef.bool(forKey: K.UserDefaultsKeys.isLoggingOvertime)
+        self.isLoggingOvertime = userDef.bool(forKey: SettingsStore.SettingKey.isLoggingOvertime.rawValue)//K.UserDefaultsKeys.isLoggingOvertime)
         self.isSendingNotifications = userDef.bool(forKey: K.UserDefaultsKeys.isSendingNotifications)
         self.netPayAvaliable = userDef.bool(forKey: K.UserDefaultsKeys.isCalculatingNetPay)
         self.grossPayPerMonth = userDef.integer(forKey: K.UserDefaultsKeys.grossPayPerMonth)

--- a/ClockIn/ViewModel/OnboardingViewModel.swift
+++ b/ClockIn/ViewModel/OnboardingViewModel.swift
@@ -29,27 +29,37 @@ class OnboardingViewModel: ObservableObject {
     }
     
     private func setPublishers() {
-        $hoursWorking.sink { [weak self] newValue in
+        $hoursWorking
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .sink { [weak self] newValue in
             guard let self else { return }
             self.settingsStore.workTimeInSeconds = self.calculateTimeInSeconds(hours: newValue, minutes: self.minutesWorking)
         }.store(in: &subscriptions)
         
-        $minutesWorking.sink { [weak self] newValue in
+        $minutesWorking
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .sink { [weak self] newValue in
             guard let self else { return }
             self.settingsStore.workTimeInSeconds = self.calculateTimeInSeconds(hours: self.hoursWorking, minutes: newValue)
         }.store(in: &subscriptions)
         
-        $hoursOvertime.sink { [weak self] newValue in
+        $hoursOvertime
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .sink { [weak self] newValue in
             guard let self else { return }
             self.settingsStore.maximumOvertimeAllowedInSeconds = self.calculateTimeInSeconds(hours: newValue, minutes: self.minutesOvertime)
         }.store(in: &subscriptions)
         
-        $minutesOvertime.sink { [weak self] newValue in
+        $minutesOvertime
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .sink { [weak self] newValue in
             guard let self else { return }
             self.settingsStore.maximumOvertimeAllowedInSeconds = self.calculateTimeInSeconds(hours: self.hoursOvertime, minutes: newValue)
         }.store(in: &subscriptions)
         
-        $grossPayPerMonthText.sink { [weak self] newValue in
+        $grossPayPerMonthText
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .sink { [weak self] newValue in
             guard let self else { return }
             let filtered = newValue.filter({ "0123456789".contains($0) })
             if let newGross = Int(filtered) {

--- a/ClockIn/ViewModel/SettingViewModel.swift
+++ b/ClockIn/ViewModel/SettingViewModel.swift
@@ -75,11 +75,8 @@ class SettingsViewModel: ObservableObject {
     private func setWorkTimeSubscribers() {
         $timerHours
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .removeDuplicates()
             .combineLatest($timerMinutes.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main))
-            .filter({ [weak self] (hours, minutes) in
-                guard let self else { return false }
-                return self.settingsStore.workTimeInSeconds != self.calculateTimeInSeconds(hours: hours, minutes: minutes)
-            })
             .sink { [weak self] (hours, minutes) in
                 guard let self else { return }
                 let newWorkTime = self.calculateTimeInSeconds(hours: hours, minutes: minutes )
@@ -90,11 +87,8 @@ class SettingsViewModel: ObservableObject {
         
         $timerMinutes
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .removeDuplicates()
             .combineLatest($timerHours.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main))
-            .filter({ [weak self] (minutes, hours) in
-                guard let self else { return false }
-                return self.settingsStore.workTimeInSeconds != self.calculateTimeInSeconds(hours: hours, minutes: minutes)
-            })
             .sink { [weak self] (minutes, hours) in
             guard let self else { return }
                 self.settingsStore.workTimeInSeconds = self.calculateTimeInSeconds(hours: hours, minutes: minutes)
@@ -104,11 +98,8 @@ class SettingsViewModel: ObservableObject {
     private func setOvertimeSubscribers() {
         $overtimeHours
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .removeDuplicates()
             .combineLatest($overtimeMinutes.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main))
-            .filter { [weak self] (hours, minutes) in
-                guard let self else { return false }
-                return self.settingsStore.maximumOvertimeAllowedInSeconds != self.calculateTimeInSeconds(hours: hours, minutes: minutes)
-            }
             .sink { [weak self] (hours, minutes) in
                 guard let self else { return }
                 self.settingsStore.maximumOvertimeAllowedInSeconds = self.calculateTimeInSeconds(hours: hours, minutes: minutes)
@@ -116,11 +107,8 @@ class SettingsViewModel: ObservableObject {
         
         $overtimeMinutes
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .removeDuplicates()
             .combineLatest($overtimeHours.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main))
-            .filter { [weak self] (minutes, hours) in
-                guard let self else { return false }
-                return self.settingsStore.maximumOvertimeAllowedInSeconds != self.calculateTimeInSeconds(hours: hours, minutes: minutes)
-            }
             .sink { [weak self] (minutes, hours) in
                 guard let self else { return }
                 self.settingsStore.maximumOvertimeAllowedInSeconds =  self.calculateTimeInSeconds(hours: hours, minutes: minutes)

--- a/ClockIn/ViewModel/SettingViewModel.swift
+++ b/ClockIn/ViewModel/SettingViewModel.swift
@@ -5,131 +5,136 @@
 //  Created by Tomasz Kubiak on 4/3/23.
 //
 
-import Foundation
+import Combine
 import SwiftUI
 
 class SettingsViewModel: ObservableObject {
+    private var subscriptions = Set<AnyCancellable>()
     
     private var dataManager: DataManager
-    @Published private var settingsStore: SettingsStore
-    // UI values
-    @Published var timerHours: Int = 8 {
-        didSet {
-            workTimeInSeconds = timerHours * 3600 + timerMinutes * 60
-        }
-    }
-    @Published var timerMinutes: Int = 0 {
-        didSet {
-            workTimeInSeconds = timerHours * 3600 + timerMinutes * 60
-        }
-    }
-    @Published var overtimeHours: Int = 0 {
-        didSet {
-            maximumOvertimeAllowedInSeconds = overtimeHours * 3600 + overtimeMinutes * 60
-        }
-    }
-    @Published var overtimeMinutes: Int = 0 {
-        didSet {
-            maximumOvertimeAllowedInSeconds = overtimeHours * 3600 + overtimeMinutes * 60
-        }
-    }
-    
-    //UserDefaults
-    @Published var isLoggingOverTime: Bool = false {
-        didSet {
-            //On didSet write to userDefaults
-            UserDefaults.standard.set(isLoggingOverTime, forKey: K.UserDefaultsKeys.isLoggingOvertime)
-        }
-    }
-    @Published var preferredColorScheme: String = "system" {
-        didSet {
-            UserDefaults.standard.set(preferredColorScheme, forKey: K.UserDefaultsKeys.savedColorScheme)
-        }
-    }
-    @Published var maximumOvertimeAllowedInSeconds: Int = 18000 {
-        didSet {
-            UserDefaults.standard.set(maximumOvertimeAllowedInSeconds, forKey: K.UserDefaultsKeys.maximumOverTimeAllowedInSeconds)
-        }
-    }
-    @Published var isSendingNotifications: Bool = true {
-        didSet {
-            if isSendingNotifications == true {
-                requestAuthorizationForNotifications()
-            }
-            UserDefaults.standard.set(isSendingNotifications, forKey: K.UserDefaultsKeys.isSendingNotifications)
-        }
-    }
-    @Published var grossPayPerMonth: Int {
-        didSet {
-            UserDefaults.standard.set(grossPayPerMonth, forKey: K.UserDefaultsKeys.grossPayPerMonth)
-        }
-    }
-    @Published var calculateNetPaycheck: Bool = false {
-        didSet {
-            UserDefaults.standard.set(calculateNetPaycheck, forKey: K.UserDefaultsKeys.isCalculatingNetPay)
-        }
-    }
-    @Published var grossPayPerMonthText: String = "" {
-        didSet {
-            //Perform text validation here by filtering non-numbers
-            let filtered = grossPayPerMonthText.filter({"0123456789".contains($0)})
-            if let newGross = Int(filtered) {
-                grossPayPerMonth = newGross
-            }
-        }
-    }
-    private var workTimeInSeconds: Int = 28800 {
-        didSet {
-            UserDefaults.standard.set(workTimeInSeconds, forKey: K.UserDefaultsKeys.workTimeInSeconds)
-        }
-    }
+    @Published var settingsStore: SettingsStore
+    @Published var timerHours: Int
+    @Published var timerMinutes: Int
+    @Published var overtimeHours: Int
+    @Published var overtimeMinutes: Int
+    @Published var grossPayPerMonthText: String
     
     init(dataManger: DataManager, settingsStore: SettingsStore) {
         self.dataManager = dataManger
         self.settingsStore = settingsStore
-        //        on init retrieve values
-        self.isLoggingOverTime = UserDefaults.standard.bool(forKey: K.UserDefaultsKeys.isLoggingOvertime)
-        self.preferredColorScheme = UserDefaults.standard.string(forKey: K.UserDefaultsKeys.savedColorScheme) ?? "system"
-        self.maximumOvertimeAllowedInSeconds = UserDefaults.standard.integer(forKey: K.UserDefaultsKeys.maximumOverTimeAllowedInSeconds)
-        self.isSendingNotifications = UserDefaults.standard.bool(forKey: K.UserDefaultsKeys.isSendingNotifications)
-        self.workTimeInSeconds = UserDefaults.standard.integer(forKey: K.UserDefaultsKeys.workTimeInSeconds)
-        self.grossPayPerMonth = UserDefaults.standard.integer(forKey: K.UserDefaultsKeys.grossPayPerMonth)
-        self.calculateNetPaycheck = UserDefaults.standard.bool(forKey: K.UserDefaultsKeys.isCalculatingNetPay)
+        self.timerHours = settingsStore.workTimeInSeconds / 3600
+        self.timerMinutes = (settingsStore.workTimeInSeconds % 3600) / 60
+        self.overtimeHours = settingsStore.maximumOvertimeAllowedInSeconds / 3600
+        self.overtimeMinutes = (settingsStore.maximumOvertimeAllowedInSeconds % 3600) / 60
+        self.grossPayPerMonthText = String(settingsStore.grossPayPerMonth)
+        setSubscribers()
+    }
+    private func setSubscribers() {
         
-        self.grossPayPerMonthText = String(self.grossPayPerMonth)
-        self.timerHours = workTimeInSeconds / 3600
-        self.timerMinutes = (workTimeInSeconds % 3600) / 60
-        print(timerMinutes)
-        self.overtimeHours = 5
-        self.overtimeMinutes = 0
-        self.overtimeHours = maximumOvertimeAllowedInSeconds / 3600
-        self.overtimeMinutes = (maximumOvertimeAllowedInSeconds % 3600) / 60
+        settingsStore.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.objectWillChange.send()
+                self.timerHours = settingsStore.workTimeInSeconds / 3600
+                self.timerMinutes = (settingsStore.workTimeInSeconds % 3600) / 60
+                self.overtimeHours = settingsStore.maximumOvertimeAllowedInSeconds / 3600
+                self.overtimeMinutes = (settingsStore.maximumOvertimeAllowedInSeconds % 3600) / 60
+                self.grossPayPerMonthText = String(settingsStore.grossPayPerMonth)
+            }.store(in: &subscriptions)
+        
+        settingsStore.$isSendingNotification
+            .filter({ $0 })
+            .sink { [weak self] value in
+                guard let self else { return }
+                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge], completionHandler: { success, error in
+                    if let error = error {
+                        print(error.localizedDescription)
+                        self.settingsStore.isSendingNotification = false
+                    }
+                })
+            }.store(in: &subscriptions)
+        
+        setWorkTimeSubscribers()
+        setOvertimeSubscribers()
+        setGrossPaySubscribers()
+        
     }
     
+    private func setGrossPaySubscribers() {
+        $grossPayPerMonthText.sink { [weak self] value in
+            guard let self else { return }
+            let filtered = value.filter({"0123456789".contains($0)})
+            if let newGross = Int(filtered) {
+                self.settingsStore.grossPayPerMonth = newGross
+            }
+        }.store(in: &subscriptions)
+                
+    }
+    
+    private func setWorkTimeSubscribers() {
+        $timerHours
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .combineLatest($timerMinutes.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main))
+            .filter({ [weak self] (hours, minutes) in
+                guard let self else { return false }
+                return self.settingsStore.workTimeInSeconds != self.calculateTimeInSeconds(hours: hours, minutes: minutes)
+            })
+            .sink { [weak self] (hours, minutes) in
+                guard let self else { return }
+                let newWorkTime = self.calculateTimeInSeconds(hours: hours, minutes: minutes )
+                if newWorkTime != self.settingsStore.workTimeInSeconds {
+                    self.settingsStore.workTimeInSeconds = newWorkTime
+                }
+            }.store(in: &subscriptions)
+        
+        $timerMinutes
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .combineLatest($timerHours.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main))
+            .filter({ [weak self] (minutes, hours) in
+                guard let self else { return false }
+                return self.settingsStore.workTimeInSeconds != self.calculateTimeInSeconds(hours: hours, minutes: minutes)
+            })
+            .sink { [weak self] (minutes, hours) in
+            guard let self else { return }
+                self.settingsStore.workTimeInSeconds = self.calculateTimeInSeconds(hours: hours, minutes: minutes)
+            }.store(in: &subscriptions)
+    }
+    
+    private func setOvertimeSubscribers() {
+        $overtimeHours
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .combineLatest($overtimeMinutes.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main))
+            .filter { [weak self] (hours, minutes) in
+                guard let self else { return false }
+                return self.settingsStore.maximumOvertimeAllowedInSeconds != self.calculateTimeInSeconds(hours: hours, minutes: minutes)
+            }
+            .sink { [weak self] (hours, minutes) in
+                guard let self else { return }
+                self.settingsStore.maximumOvertimeAllowedInSeconds = self.calculateTimeInSeconds(hours: hours, minutes: minutes)
+            }.store(in: &subscriptions)
+        
+        $overtimeMinutes
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .combineLatest($overtimeHours.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main))
+            .filter { [weak self] (minutes, hours) in
+                guard let self else { return false }
+                return self.settingsStore.maximumOvertimeAllowedInSeconds != self.calculateTimeInSeconds(hours: hours, minutes: minutes)
+            }
+            .sink { [weak self] (minutes, hours) in
+                guard let self else { return }
+                self.settingsStore.maximumOvertimeAllowedInSeconds =  self.calculateTimeInSeconds(hours: hours, minutes: minutes)
+            }.store(in: &subscriptions)
+    }
+    
+    private func calculateTimeInSeconds(hours: Int, minutes: Int) -> Int {
+        return hours * 3600 + minutes * 60
+    }
     func deleteAllData() {
         dataManager.deleteAll()
     }
     
     func resetUserDefaults() {
-        isSendingNotifications =  true
-        isLoggingOverTime = false
-        preferredColorScheme = K.ColorScheme.system.rawValue
-        maximumOvertimeAllowedInSeconds = 18000
-        workTimeInSeconds = 28800
-        timerHours = 8
-        timerMinutes = 0
-        overtimeHours = 0
-        overtimeMinutes = 0
-        print("Reseted user defaults to given values")
-    }
-    
-    func requestAuthorizationForNotifications() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge], completionHandler: { success, error in
-            if success {
-                print("Autorization success")
-            } else if let error = error {
-                print(error.localizedDescription)
-            }
-        })
+        SettingsStore.clearUserDefaults()
     }
 }

--- a/ClockIn/ViewModel/SettingViewModel.swift
+++ b/ClockIn/ViewModel/SettingViewModel.swift
@@ -12,10 +12,7 @@ class SettingsViewModel: ObservableObject {
     
     private var dataManager: DataManager
     @Published private var settingsStore: SettingsStore
-    //View states
-    @Published var isShowingWorkTimeEditor: Bool = false
-    @Published var isShowingOverTimeEditor: Bool = false
-    
+    // UI values
     @Published var timerHours: Int = 8 {
         didSet {
             workTimeInSeconds = timerHours * 3600 + timerMinutes * 60

--- a/ClockIn/ViewModel/SettingViewModel.swift
+++ b/ClockIn/ViewModel/SettingViewModel.swift
@@ -11,7 +11,7 @@ import SwiftUI
 class SettingsViewModel: ObservableObject {
     
     private var dataManager: DataManager
-    
+    @Published private var settingsStore: SettingsStore
     //View states
     @Published var isShowingWorkTimeEditor: Bool = false
     @Published var isShowingOverTimeEditor: Bool = false
@@ -87,8 +87,9 @@ class SettingsViewModel: ObservableObject {
         }
     }
     
-    init(dataManger: DataManager = DataManager.shared ) {
+    init(dataManger: DataManager, settingsStore: SettingsStore) {
         self.dataManager = dataManger
+        self.settingsStore = settingsStore
         //        on init retrieve values
         self.isLoggingOverTime = UserDefaults.standard.bool(forKey: K.UserDefaultsKeys.isLoggingOvertime)
         self.preferredColorScheme = UserDefaults.standard.string(forKey: K.UserDefaultsKeys.savedColorScheme) ?? "system"
@@ -101,6 +102,7 @@ class SettingsViewModel: ObservableObject {
         self.grossPayPerMonthText = String(self.grossPayPerMonth)
         self.timerHours = workTimeInSeconds / 3600
         self.timerMinutes = (workTimeInSeconds % 3600) / 60
+        print(timerMinutes)
         self.overtimeHours = 5
         self.overtimeMinutes = 0
         self.overtimeHours = maximumOvertimeAllowedInSeconds / 3600

--- a/ClockInUITests/OnboardingUITests.swift
+++ b/ClockInUITests/OnboardingUITests.swift
@@ -62,6 +62,9 @@ final class OnboardingUITests: XCTestCase {
             expectation(for: existsPredicate, evaluatedWith: onboardingScreen.calculateNetSalaryToggleButton),
             expectation(for: existsPredicate, evaluatedWith: onboardingScreen.regressStageButton)
         ]
+        let dismissedExpectations = [
+            expectation(for: notExistPredicate, evaluatedWith: onboardingScreen.advanceStageButton)
+        ]
         // Then
         let initialStageResult = XCTWaiter.wait(for: zeroStageExpectations, timeout: standardTimeout)
         XCTAssertEqual(initialStageResult, .completed, "Advance stage button should exist")
@@ -85,6 +88,12 @@ final class OnboardingUITests: XCTestCase {
         // Then
         let fourthStageResult = XCTWaiter.wait(for: fourthStageExpectations, timeout: standardTimeout)
         XCTAssertEqual(fourthStageResult, .completed, "Fourth stage elements should exist")
+        // When
+        onboardingScreen.advanceStageButton.tap(withNumberOfTaps: 2, numberOfTouches: 1)
+        // Then
+        let dismissedResult = XCTWaiter.wait(for: dismissedExpectations, timeout: standardTimeout)
+        XCTAssertEqual(dismissedResult, .completed, "The view should not exist")
+        
     }
     
     func test_OnboardingUserFlow() {
@@ -123,6 +132,7 @@ final class OnboardingUITests: XCTestCase {
         XCTAssertEqual(settingsScreen.grossPaycheckTextField.value as! String, "10000")
         XCTAssertEqual(settingsScreen.calculateNetPayToggle.value as? String, "1")
         XCTAssertEqual(settingsScreen.sendNotificationsToggle.value as? String, "1")
+        // something is wrong with this one?
         XCTAssertEqual(settingsScreen.keepLogginOvertimeToggle.value as? String, "1")
         // When
         settingsScreen.setTimeLengthExpandText.tap()


### PR DESCRIPTION
This PR introduces singular store for all user default properties used in the app. It makes the read and writes easier, more safe and brings one point, where the state of the user settings is encapsulated. It also makes it easier to manage the user settings for tests, since the SettingStore can be set to erase user defaults, provide specific test conditions without interacting with tested modules. 

In this PR I: 
- removed the direct use of the user defaults from view models, and redirected in to a setting store retrieved from container. 
- Changed any stringly typed user keys into a new enum 
- changed the did set function to combine framework subscribers 
- moved some of the view related logic out of the view models and into the view 
- Fixed the issue with setting view not displaying correctly the values set in oboarding due to different time initialisation of the setting view model