### PR TITLE
Add settings view UI tests

### DIFF
--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		D6842EC429EC62DE00731E84 /* PayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6842EC329EC62DD00731E84 /* PayManager.swift */; };
 		D6842EC629EC6FDF00731E84 /* PayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6842EC529EC6FDE00731E84 /* PayManagerTests.swift */; };
 		D6AB737029F562E600D5DE82 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AB736F29F562E600D5DE82 /* OnboardingViewModel.swift */; };
+		D6B3B2662ABA237800101A1F /* SettingsViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B3B2652ABA237800101A1F /* SettingsViewUITests.swift */; };
 		D6C4589429D229210069D89B /* ClockInApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C4589329D229210069D89B /* ClockInApp.swift */; };
 		D6C4589629D229210069D89B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C4589529D229210069D89B /* ContentView.swift */; };
 		D6C4589829D229230069D89B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D6C4589729D229230069D89B /* Assets.xcassets */; };
@@ -108,6 +109,7 @@
 		D6842EC329EC62DD00731E84 /* PayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayManager.swift; sourceTree = "<group>"; };
 		D6842EC529EC6FDE00731E84 /* PayManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayManagerTests.swift; sourceTree = "<group>"; };
 		D6AB736F29F562E600D5DE82 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
+		D6B3B2652ABA237800101A1F /* SettingsViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewUITests.swift; sourceTree = "<group>"; };
 		D6C4589029D229210069D89B /* ClockIn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ClockIn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6C4589329D229210069D89B /* ClockInApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockInApp.swift; sourceTree = "<group>"; };
 		D6C4589529D229210069D89B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 				D6ED26BE2AA3BA05001E2390 /* OnboardingUITests.swift */,
 				D6C458AE29D229230069D89B /* ClockInUITests.swift */,
 				D6C458B029D229230069D89B /* ClockInUITestsLaunchTests.swift */,
+				D6B3B2652ABA237800101A1F /* SettingsViewUITests.swift */,
 			);
 			path = ClockInUITests;
 			sourceTree = "<group>";
@@ -496,6 +499,7 @@
 				D67332E72AADB8B1005FFE7F /* LaunchArgument.swift in Sources */,
 				D610074B2AAB8BC800503C28 /* HistoryViewUITests.swift in Sources */,
 				D610074D2AAC77F300503C28 /* EditSheetScreen.swift in Sources */,
+				D6B3B2662ABA237800101A1F /* SettingsViewUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ClockIn/Model/Container.swift
+++ b/ClockIn/Model/Container.swift
@@ -29,18 +29,12 @@ class Container: ObservableObject {
         
         if CommandLine.arguments.contains(LaunchArgument.withOnboarding.rawValue) {
             SettingsStore.clearUserDefaults()
-            self.settingsStore = SettingsStore()
-            settingsStore.isRunFirstTime = true
-            containerType = .test
-        } else {
-            self.settingsStore = SettingsStore()
+        } else if CommandLine.arguments.contains(LaunchArgument.setTestUserDefaults.rawValue) {
+            SettingsStore.setTestUserDefaults()
         }
+        self.settingsStore = SettingsStore()
         
         if CommandLine.arguments.contains(LaunchArgument.inMemoryPresistenStore.rawValue) {
-            containerType = .test
-        }
-        if CommandLine.arguments.contains(LaunchArgument.setTestUserDefaults.rawValue) {
-            UserDefaults.standard.set(false, forKey: K.UserDefaultsKeys.isRunFirstTime)
             containerType = .test
         }
         

--- a/ClockIn/Model/SettingsStore.swift
+++ b/ClockIn/Model/SettingsStore.swift
@@ -133,6 +133,18 @@ final class SettingsStore: ObservableObject {
         }
     }
     
+    static func setTestUserDefaults() {
+        let defaults = UserDefaults.standard
+        defaults.set(false, forKey: SettingKey.isRunFirstTime.rawValue)
+        defaults.set(true, forKey: SettingKey.isLoggingOvertime.rawValue)
+        defaults.set(true, forKey: SettingKey.isCalculatingNetPay.rawValue)
+        defaults.set(false, forKey: SettingKey.isSendingNotifications.rawValue)
+        defaults.set(28800, forKey: SettingKey.workTimeInSeconds.rawValue)
+        defaults.set(14400, forKey: SettingKey.maximumOvertimeAllowedInSeconds.rawValue)
+        defaults.set(10000, forKey: SettingKey.grossPayPerMonth.rawValue)
+        defaults.set(nil as ColorScheme?, forKey: SettingKey.savedColorScheme.rawValue)
+    }
+    
     private func updateSetting<T>(setting: SettingKey, value: T) {
         defaults.set(value, forKey: setting.rawValue)
     }

--- a/ClockIn/Model/SettingsStore.swift
+++ b/ClockIn/Model/SettingsStore.swift
@@ -110,12 +110,11 @@ final class SettingsStore: ObservableObject {
     func clearStore() {
         subscriptions.removeAll()
         for key in SettingKey.allCases {
-            UserDefaults.standard.removeObject(forKey: key.rawValue)
-        }
-        if let value = defaults.value(forKey: SettingKey.isRunFirstTime.rawValue) as? Bool {
-            self.isRunFirstTime = value
-        } else {
-            self.isRunFirstTime = true
+            if key != .isRunFirstTime {
+                UserDefaults.standard.removeObject(forKey: key.rawValue)
+            } else {
+                updateSetting(setting: key, value: false)
+            }
         }
         isLoggingOvertime = defaults.bool(forKey: SettingKey.isLoggingOvertime.rawValue)
         isCalculatingNetPay = defaults.bool(forKey: SettingKey.isCalculatingNetPay.rawValue)

--- a/ClockIn/ViewModel/SettingViewModel.swift
+++ b/ClockIn/ViewModel/SettingViewModel.swift
@@ -75,7 +75,7 @@ class SettingsViewModel: ObservableObject {
     private func setWorkTimeSubscribers() {
         $timerHours
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
-            .removeDuplicates()
+//            .removeDuplicates()
             .combineLatest($timerMinutes.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main))
             .sink { [weak self] (hours, minutes) in
                 guard let self else { return }
@@ -87,7 +87,7 @@ class SettingsViewModel: ObservableObject {
         
         $timerMinutes
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
-            .removeDuplicates()
+//            .removeDuplicates()
             .combineLatest($timerHours.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main))
             .sink { [weak self] (minutes, hours) in
             guard let self else { return }

--- a/ClockInUITests/OnboardingUITests.swift
+++ b/ClockInUITests/OnboardingUITests.swift
@@ -118,8 +118,8 @@ final class OnboardingUITests: XCTestCase {
         let result = XCTWaiter.wait(for: overtimePickersExpectations, timeout: standardTimeout)
         XCTAssertEqual(result, .completed, "After overtime toggles is set to true, overtime hours and minutes pickers should exist")
         // When
-        onboardingScreen.overtimeHoursPicker.children(matching: .pickerWheel).firstMatch.adjust(toPickerWheelValue: "4")
         onboardingScreen.overtimeMinutesPicker.children(matching: .pickerWheel).firstMatch.adjust(toPickerWheelValue: "30")
+        onboardingScreen.overtimeHoursPicker.children(matching: .pickerWheel).firstMatch.adjust(toPickerWheelValue: "4")
         onboardingScreen.advanceStageButton.tap()
         onboardingScreen.notificationToggleButton.switches.firstMatch.tap()
         onboardingScreen.advanceStageButton.tap()

--- a/ClockInUITests/SettingsViewUITests.swift
+++ b/ClockInUITests/SettingsViewUITests.swift
@@ -1,0 +1,76 @@
+//
+//  SettingsViewUITests.swift
+//  ClockInUITests
+//
+//  Created by Tomasz Kubiak on 19/09/2023.
+//
+
+import XCTest
+
+final class SettingsViewUITests: XCTestCase {
+    
+    private let standardTimeout: Double = 2.5
+    private var app: XCUIApplication!
+    private let existsPredicate = NSPredicate(format: "exists == true")
+    
+    private var settingsScreen: SettingsViewScreen {
+        SettingsViewScreen(app: app)
+    }
+    
+    override func setUp() {
+        super.setUp()
+        app = .init()
+        app.launchArguments = [
+            LaunchArgument.setTestUserDefaults.rawValue
+        ]
+        app.launch()
+    }
+    
+    override func tearDown() {
+        app = nil
+    }
+    
+    func test_SettingsViewInitialScreenConfiguration() {
+        // Given
+        let notExpandedElementsExpectations = [
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.setTimeLengthExpandText),
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.setOvertimeLengthExpandButton),
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.keepLogginOvertimeToggle),
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.grossPaycheckTextField),
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.calculateNetPayToggle),
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.clearAllSavedDataButton),
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.resetPreferencesButton),
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.sendNotificationsToggle),
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.appearanceDarkButton),
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.appearanceLightButton),
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.appearanceSystemButton)
+        ]
+        let worktimePickerExpectations = [
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.workTimeHoursPicker),
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.workMinutesHoursPicker)
+        ]
+        let overtimePickerExpectations = [
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.overtimeHoursPicker),
+            expectation(for: existsPredicate, evaluatedWith: settingsScreen.overtimeMinutesPicker)
+        ]
+        navigateToSettingsView()
+        // Then
+        let notExpandedElementsResult = XCTWaiter.wait(for: notExpandedElementsExpectations, timeout: standardTimeout)
+        XCTAssertEqual(notExpandedElementsResult, .completed, "Elements should exist")
+        // When
+        settingsScreen.setTimeLengthExpandText.tap()
+        // Then
+        let worktimePickerResult = XCTWaiter.wait(for: worktimePickerExpectations, timeout: standardTimeout)
+        XCTAssertEqual(worktimePickerResult, .completed, "Work time pickers should exist")
+        // When
+        settingsScreen.setTimeLengthExpandText.tap()
+        settingsScreen.setOvertimeLengthExpandButton.tap()
+        // Then
+        let overtimePickerResult = XCTWaiter.wait(for: overtimePickerExpectations, timeout: standardTimeout)
+        XCTAssertEqual(overtimePickerResult, .completed, " Overtime pickers should exist")
+    }
+    
+    private func navigateToSettingsView() {
+        HomeViewScreen(app: app).settingsNavigationButton.tap()
+    }
+}

--- a/ClockInUITests/SettingsViewUITests.swift
+++ b/ClockInUITests/SettingsViewUITests.swift
@@ -137,6 +137,7 @@ final class SettingsViewUITests: XCTestCase {
         // When
         settingsScreen.overtimeHoursPicker.pickerWheels.firstMatch.adjust(toPickerWheelValue: expectedValues[.overtimeHours]!)
         settingsScreen.overtimeMinutesPicker.pickerWheels.firstMatch.adjust(toPickerWheelValue: expectedValues[.overtimeMinutes]!)
+        settingsScreen.setOvertimeLengthExpandButton.tap()
         restartApp()
         navigateToSettingsView()
         settingsScreen.setTimeLengthExpandText.tap()

--- a/ClockInUITests/SettingsViewUITests.swift
+++ b/ClockInUITests/SettingsViewUITests.swift
@@ -21,7 +21,8 @@ final class SettingsViewUITests: XCTestCase {
         super.setUp()
         app = .init()
         app.launchArguments = [
-            LaunchArgument.setTestUserDefaults.rawValue
+            LaunchArgument.setTestUserDefaults.rawValue,
+            LaunchArgument.inMemoryPresistenStore.rawValue
         ]
         app.launch()
     }
@@ -199,6 +200,21 @@ final class SettingsViewUITests: XCTestCase {
         // Then
         let finalOvertimePickerResult = XCTWaiter.wait(for: finalPickerOvertimeValueExpectations, timeout: standardTimeout)
         XCTAssertEqual(finalOvertimePickerResult, .completed, "The overtime pickers should show 0s")
+    }
+    
+    func test_ClearSavedData() {
+        // Given
+        navigateToSettingsView()
+        // When
+        settingsScreen.clearAllSavedDataButton.tap()
+        app.navigationBars.buttons.firstMatch.tap()
+        HomeViewScreen(app: app).statisticsNavigationButton.tap()
+        StatisticsViewScreen(app: app).detailedHistoryNavigationButton.tap()
+        // Then
+        let countPredicate = NSPredicate(format: "count == 0")
+        let expectation = expectation(for: countPredicate, evaluatedWith: app.collectionViews.cells)
+        let result = XCTWaiter.wait(for: [expectation], timeout: standardTimeout)
+        XCTAssertEqual(result, .completed, "There should be no cells in app")
     }
     
     private func restartApp() {

--- a/ClockInUITests/SettingsViewUITests.swift
+++ b/ClockInUITests/SettingsViewUITests.swift
@@ -70,6 +70,42 @@ final class SettingsViewUITests: XCTestCase {
         XCTAssertEqual(overtimePickerResult, .completed, " Overtime pickers should exist")
     }
     
+    func test_toggleButtonsRetainValues() {
+        // Given
+        navigateToSettingsView()
+        let initialValues: [String?] = [
+            settingsScreen.sendNotificationsToggle.value as? String,
+            settingsScreen.keepLogginOvertimeToggle.value as? String,
+            settingsScreen.calculateNetPayToggle.value as? String
+        ]
+        // When
+        settingsScreen.sendNotificationsToggle.switches.firstMatch.tap()
+        settingsScreen.keepLogginOvertimeToggle.switches.firstMatch.tap()
+        settingsScreen.calculateNetPayToggle.switches.firstMatch.tap()
+        // Then
+        let exitValues: [String?] = [
+            settingsScreen.sendNotificationsToggle.value as? String,
+            settingsScreen.keepLogginOvertimeToggle.value as? String,
+            settingsScreen.calculateNetPayToggle.value as? String
+        ]
+        XCTAssertNotEqual(exitValues[0], initialValues[0])
+        XCTAssertNotEqual(exitValues[1], initialValues[1])
+        XCTAssertNotEqual(exitValues[2], initialValues[2])
+        // When
+        app.terminate()
+        app = nil
+        app = .init()
+        app.launch()
+        navigateToSettingsView()
+        // Then
+        let resumeValues: [String?] = [
+            settingsScreen.sendNotificationsToggle.value as? String,
+            settingsScreen.keepLogginOvertimeToggle.value as? String,
+            settingsScreen.calculateNetPayToggle.value as? String
+        ]
+        XCTAssertEqual(exitValues, resumeValues)
+    }
+    
     private func navigateToSettingsView() {
         HomeViewScreen(app: app).settingsNavigationButton.tap()
     }

--- a/ClockInUITests/SettingsViewUITests.swift
+++ b/ClockInUITests/SettingsViewUITests.swift
@@ -154,6 +154,53 @@ final class SettingsViewUITests: XCTestCase {
         XCTAssertEqual(expectedValues[.overtimeMinutes]!, settingsScreen.overtimeMinutesPicker.pickerWheels.firstMatch.value as? String)
     }
     
+    func test_resetUserDefaults() {
+        // Given
+        let valuePredicate = NSPredicate(format: "value == '0'")
+        let initialToggleValueExpectations = generateToggleExpecations(predicate: valuePredicate)
+        let initialPickerWorkValueExpectations = generatePickerWorkExpectations(predicate: valuePredicate)
+        let initialPickerOvertimeValueExpectations = generatePickerOvertimeExpectations(predicate: valuePredicate)
+        let finalToggleValueExpectations = generateToggleExpecations(predicate: valuePredicate)
+        let finalPickerWorkValueExpectations = generatePickerWorkExpectations(predicate: valuePredicate)
+        let finalPickerOvertimeValueExpectations = generatePickerOvertimeExpectations(predicate: valuePredicate)
+        navigateToSettingsView()
+        // When
+        settingsScreen.resetPreferencesButton.tap()
+        // Then
+        let initialTogglesResult = XCTWaiter.wait(for: initialToggleValueExpectations, timeout: standardTimeout)
+        XCTAssertEqual(initialTogglesResult, .completed, "The toggles should have false value")
+        XCTAssertEqual(settingsScreen.grossPaycheckTextField.value as? String, "0", "TextField should show '0'")
+        // When
+        settingsScreen.setTimeLengthExpandText.tap()
+        // Then
+        let initialWorkPickerResult = XCTWaiter.wait(for: initialPickerWorkValueExpectations, timeout: standardTimeout)
+        XCTAssertEqual(initialWorkPickerResult, .completed, "The work time pickers should show 0s")
+        // When
+        settingsScreen.setTimeLengthExpandText.tap()
+        settingsScreen.setOvertimeLengthExpandButton.tap()
+        // Then
+        let initialOvertimePickerResult = XCTWaiter.wait(for: initialPickerOvertimeValueExpectations, timeout: standardTimeout)
+        XCTAssertEqual(initialOvertimePickerResult, .completed, "The overtime pickers should show 0s")
+        // When
+        restartApp()
+        navigateToSettingsView()
+        // Then
+        let finalTogglesResult = XCTWaiter.wait(for: finalToggleValueExpectations, timeout: standardTimeout)
+        XCTAssertEqual(finalTogglesResult, .completed, "The toggles should have false value")
+        XCTAssertEqual(settingsScreen.grossPaycheckTextField.value as? String, "0", "TextField should be show '0'")
+        // When
+        settingsScreen.setTimeLengthExpandText.tap()
+        // Then
+        let finalWorkPickerResult = XCTWaiter.wait(for: finalPickerWorkValueExpectations, timeout: standardTimeout)
+        XCTAssertEqual(finalWorkPickerResult, .completed, "The work time pickers should show 0s")
+        // When
+        settingsScreen.setTimeLengthExpandText.tap()
+        settingsScreen.setOvertimeLengthExpandButton.tap()
+        // Then
+        let finalOvertimePickerResult = XCTWaiter.wait(for: finalPickerOvertimeValueExpectations, timeout: standardTimeout)
+        XCTAssertEqual(finalOvertimePickerResult, .completed, "The overtime pickers should show 0s")
+    }
+    
     private func restartApp() {
         app.terminate()
         app = nil
@@ -163,5 +210,24 @@ final class SettingsViewUITests: XCTestCase {
     
     private func navigateToSettingsView() {
         HomeViewScreen(app: app).settingsNavigationButton.tap()
+    }
+}
+
+// MARK: EXPECTATION GENERATOR FUNCTIONS
+extension SettingsViewUITests {
+    private func generateToggleExpecations(predicate: NSPredicate) -> [XCTestExpectation] {
+        [expectation(for: predicate, evaluatedWith: settingsScreen.sendNotificationsToggle),
+         expectation(for: predicate, evaluatedWith: settingsScreen.keepLogginOvertimeToggle),
+         expectation(for: predicate, evaluatedWith: settingsScreen.calculateNetPayToggle)]
+    }
+    
+    private func generatePickerWorkExpectations(predicate: NSPredicate) -> [XCTestExpectation] {
+        [expectation(for: predicate, evaluatedWith: settingsScreen.workTimeHoursPicker.pickerWheels.firstMatch),
+         expectation(for: predicate, evaluatedWith: settingsScreen.workMinutesHoursPicker.pickerWheels.firstMatch)]
+    }
+    
+    func generatePickerOvertimeExpectations(predicate: NSPredicate) -> [XCTestExpectation] {
+        [expectation(for: predicate, evaluatedWith: settingsScreen.overtimeHoursPicker.pickerWheels.firstMatch),
+         expectation(for: predicate, evaluatedWith: settingsScreen.overtimeMinutesPicker.pickerWheels.firstMatch)]
     }
 }


### PR DESCRIPTION
This PR adds UI testing for settings screen. 

In this PR I added following tests: 
- testing initial state of the view 
- testing toggle buttons and text field work and retain values between launches
- testing pickers work and retain values between launches
- testing reseting user defaults 
- testing clearing saved data 

Additionally, following issues were found and fixed during testing: 
- Updating settings store did not allow for value change on the settings pickers 
- Clearing the user default caused onboarding to reappear 
- Onboarding test had inconsistent results based on picker adjustment 
- No testing user defaults set in container, resulting in not being able to run tests consecutively