### PR TITLE
Add data pagination and list structuring to history view

### DIFF
--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		D6842EC629EC6FDF00731E84 /* PayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6842EC529EC6FDE00731E84 /* PayManagerTests.swift */; };
 		D684A3882AF6F3E700511E0D /* OnboardingWelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D684A3872AF6F3E700511E0D /* OnboardingWelcomeView.swift */; };
 		D684A38A2AF6F54B00511E0D /* ButtonFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D684A3892AF6F54B00511E0D /* ButtonFactory.swift */; };
+		D68732022B2243C9008CB0D4 /* PaginationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68732012B2243C9008CB0D4 /* PaginationState.swift */; };
 		D6AB737029F562E600D5DE82 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AB736F29F562E600D5DE82 /* OnboardingViewModel.swift */; };
 		D6B3B2662ABA237800101A1F /* SettingsViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B3B2652ABA237800101A1F /* SettingsViewUITests.swift */; };
 		D6B7D1C82B0EB41A00E6F7A8 /* ContentViewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B7D1C72B0EB41A00E6F7A8 /* ContentViewScreen.swift */; };
@@ -134,6 +135,7 @@
 		D6842EC529EC6FDE00731E84 /* PayManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayManagerTests.swift; sourceTree = "<group>"; };
 		D684A3872AF6F3E700511E0D /* OnboardingWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWelcomeView.swift; sourceTree = "<group>"; };
 		D684A3892AF6F54B00511E0D /* ButtonFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonFactory.swift; sourceTree = "<group>"; };
+		D68732012B2243C9008CB0D4 /* PaginationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationState.swift; sourceTree = "<group>"; };
 		D6AB736F29F562E600D5DE82 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		D6B3B2652ABA237800101A1F /* SettingsViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewUITests.swift; sourceTree = "<group>"; };
 		D6B7D1C72B0EB41A00E6F7A8 /* ContentViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewScreen.swift; sourceTree = "<group>"; };
@@ -367,6 +369,7 @@
 				D60EB9B52AB0D7000053136A /* Container.swift */,
 				D61F11302AB38F8700902D6D /* SettingsStore.swift */,
 				D6FA94FA2B013C770034B16A /* ChartLegendItem.swift */,
+				D68732012B2243C9008CB0D4 /* PaginationState.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -512,6 +515,7 @@
 				D64574B029D9E6A000207168 /* DataManager.swift in Sources */,
 				D6D906B12AA12BDB004E09C9 /* BackgroundFactory.swift in Sources */,
 				D6D02FB029EF0B7F006CD0B2 /* EditShetViewModel.swift in Sources */,
+				D68732022B2243C9008CB0D4 /* PaginationState.swift in Sources */,
 				D6FA94FD2B013F060034B16A /* ChartLegendItemView.swift in Sources */,
 				D6E2C15B29D6C31800229286 /* HistoryViewModel.swift in Sources */,
 				D6EA695C2AF8452A00D8F6C3 /* TextFactory.swift in Sources */,

--- a/ClockIn/Factory/PreviewDataFactory.swift
+++ b/ClockIn/Factory/PreviewDataFactory.swift
@@ -12,8 +12,7 @@ struct PreviewDataFactory {
         var result = [Entry]()
         let year = calendar.dateComponents([.year], from: date).year!
         for i in 1...12 {
-            guard let dateInMonth = calendar.date(from: DateComponents(year: year, month: i)) else { print("Failed to get date in month where i = \(i)")
-            break }
+            guard let dateInMonth = calendar.date(from: DateComponents(year: year, month: i)) else { continue }
             let dataForMonth = buildDataForPreviewForMonth(containing: dateInMonth, using: calendar)
             result.append(contentsOf: dataForMonth)
         }
@@ -30,13 +29,13 @@ struct PreviewDataFactory {
             localDateComponents.day = i
             guard let workingDate = calendar.date(from: localDateComponents),
                   !calendar.isDateInWeekend(workingDate),
-                  let entry = buildDataForDay(for: workingDate, using: calendar) else { break }
+                  let entry = buildDataForDay(for: workingDate, using: calendar) else { continue }
             result.append(entry)
         }
         return result
     }
     
-    static private func buildDataForDay(for dayDate: Date = Date(), 
+    static private func buildDataForDay(for dayDate: Date = Date(),
                                         using calendar: Calendar = .current,
                                         startDateVariation: ClosedRange<Int> = 0...4,
                                         timeLengthVariation: ClosedRange<Int> = -4...4) -> Entry? {
@@ -45,7 +44,9 @@ struct PreviewDataFactory {
         let workTime = randomLengthComponent < 0 ? (8 + randomLengthComponent) * 3600 : 8 * 3600
         let overtime = randomLengthComponent <= 0 ? 0 : randomLengthComponent * 3600
         guard let startDate = calendar.date(byAdding: .hour, value: 6 + randomStartComponent, to: dayDate),
-              let finishDate = calendar.date(byAdding: .hour, value: 8 + randomLengthComponent, to: startDate) else { return nil }
+              let finishDate = calendar.date(byAdding: .hour, value: 8 + randomLengthComponent, to: startDate) else {
+            return nil
+        }
         return Entry(
             startDate: startDate,
             finishDate: finishDate,

--- a/ClockIn/Model/PaginationState.swift
+++ b/ClockIn/Model/PaginationState.swift
@@ -1,0 +1,12 @@
+//
+//  PaginationState.swift
+//  ClockIn
+//
+//  Created by Tomasz Kubiak on 07/12/2023.
+//
+
+import Foundation
+
+enum PaginationState {
+    case isLoading, idle, error
+}

--- a/ClockIn/View/HistoryView.swift
+++ b/ClockIn/View/HistoryView.swift
@@ -60,6 +60,22 @@ struct HistoryView: View {
             return String()
         }
     }
+    
+    func makeTimeWorkedLabel(_ entry: Entry) -> String {
+        let sumWorkedInSec = entry.workTimeInSeconds + entry.overTimeInSeconds
+        let hours = sumWorkedInSec / 3600
+        let minutes = (sumWorkedInSec % 3600) / 60
+        
+        let hoursString = hours > 9 ? "\(hours)" : "0\(hours)"
+        let minutesString = minutes > 9 ? "\(minutes)" : "0\(minutes)"
+        
+        return "\(hoursString) hours \(minutesString) minutes"
+    }
+    
+    func isLastEntry(_ entry: Entry) -> Bool {
+        guard let lastEntry = viewModel.groupedEntries.last?.last else { return true }
+        return lastEntry == entry
+    }
 } // END OF STRUCT
 
 //MARK: VIEW BUILDER FUNCTIONS

--- a/ClockIn/View/HistoryView.swift
+++ b/ClockIn/View/HistoryView.swift
@@ -30,6 +30,7 @@ struct HistoryView: View {
             background
             // CONTENT LAYER
             List {
+                searchBar
                 ForEach(viewModel.entries) { entry in
                     HistoryRowViewPrototype(startDate: entry.startDate,
                                finishDate: entry.finishDate,
@@ -103,6 +104,14 @@ struct HistoryView: View {
                 Label("Settings", systemImage: "gearshape.fill")
             }
             .tint(.primary)
+        }
+    }
+    var searchBar: some View {
+        Section {
+            HStack {
+                TextField("", text: .constant(String()), prompt: Text("Search"))
+                Image(systemName: "calendar")
+            }
         }
     }
 } // END OF STRUCT

--- a/ClockIn/View/HistoryView.swift
+++ b/ClockIn/View/HistoryView.swift
@@ -95,6 +95,9 @@ extension HistoryView {
                                             overTime: viewModel.convertOvertimeToFraction(entry: entry),
                                             timeWorked: makeTimeWorkedLabel(entry))
                     .accessibilityIdentifier(Identifier.entryRow.rawValue)
+                    .onLongPressGesture(perform: {
+                        selectedEntry = entry
+                    })
                     .swipeActions {
                         makeDeleteButton(entry)
                         makeEditButton(entry)

--- a/ClockIn/View/HistoryView.swift
+++ b/ClockIn/View/HistoryView.swift
@@ -9,21 +9,17 @@ import SwiftUI
 import Charts
 
 struct HistoryView: View {
-    
     private typealias Identifier = ScreenIdentifier.HistoryView
+    let navigationTitleText: String = "History"
     @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject private var container: Container
     @StateObject private var viewModel: HistoryViewModel
     @State var selectedEntry: Entry? = nil
-    let navigationTitleText: String = "History"
+    
     init(viewModel: HistoryViewModel) {
         self._viewModel = StateObject.init(wrappedValue: viewModel)        
     }
     
-    //unused for now - have to implement
-    /*
-     @AppStorage("detail_display_mode") var detailDisplayMode: String = HistoryRow.DetailDisplayType.circleDisplay.rawValue
-     */
     var body: some View {
         ZStack {
             // BACKGROUND LAYER
@@ -31,18 +27,7 @@ struct HistoryView: View {
             // CONTENT LAYER
             List {
                 searchBar
-                ForEach(viewModel.entries) { entry in
-                    HistoryRowViewPrototype(startDate: entry.startDate,
-                               finishDate: entry.finishDate,
-                               workTime: viewModel.convertWorkTimeToFraction(entry: entry),
-                               overTime: viewModel.convertOvertimeToFraction(entry: entry),
-                               timeWorked: viewModel.timeWorkedLabel(for: entry))
-                    .accessibilityIdentifier(Identifier.entryRow.rawValue)
-                    .swipeActions {
-                        makeDeleteButton(entry)
-                        makeEditButton(entry)
-                    } // END OF SWIPE ACTIONS
-                } // END OF FOR-EACH
+                makeListConent(viewModel.entries)
             } // END OF LIST
             .scrollContentBackground(.hidden)
             .sheet(item: $selectedEntry) { entry in
@@ -58,30 +43,52 @@ struct HistoryView: View {
         .navigationTitle(navigationTitleText)
         .navigationBarTitleDisplayMode(.inline)
     } // END OF BODY
+} // END OF STRUCT
+
+//MARK: VIEW BUILDER FUNCTIONS
+extension HistoryView {
+    @ViewBuilder
+    func makeListConent(_ entries: [Entry]) -> some View {
+        ForEach(entries) { entry in
+            HistoryRowViewPrototype(startDate: entry.startDate,
+                       finishDate: entry.finishDate,
+                       workTime: viewModel.convertWorkTimeToFraction(entry: entry),
+                       overTime: viewModel.convertOvertimeToFraction(entry: entry),
+                       timeWorked: viewModel.timeWorkedLabel(for: entry))
+            .accessibilityIdentifier(Identifier.entryRow.rawValue)
+            .swipeActions {
+                makeDeleteButton(entry)
+                makeEditButton(entry)
+            } // END OF SWIPE ACTIONS
+        } // END OF FOR-EACH
+    }
+    
     @ViewBuilder
     func makeDeleteButton(_ entry: Entry) -> some View {
         Button {
             viewModel.deleteEntry(entry: entry)
         } label: {
             Image(systemName: "xmark")
-                .foregroundColor(.red)
+//                .foregroundColor(.red)
         } // END OF BUTTON
         .accessibilityIdentifier(Identifier.deleteEntryButton.rawValue)
         .tint(.red)
     }
+    
     @ViewBuilder
     func makeEditButton(_ entry: Entry) -> some View {
         Button {
             selectedEntry = entry
         } label: {
             Image(systemName: "pencil")
-                .foregroundColor(.gray)
+//                .foregroundColor(.gray)
         } // END OF BUTTON
         .accessibilityIdentifier(Identifier.editEntryButton.rawValue)
     }
-    var background: some View {
-        BackgroundFactory.buildSolidColor()
-    }
+}
+
+//MARK: VIEW COMPONENTS
+extension HistoryView {
     var addEntryToolbar: some ToolbarContent {
         ToolbarItem(placement: .navigationBarLeading) {
             Button {
@@ -93,6 +100,7 @@ struct HistoryView: View {
             .accessibilityIdentifier(Identifier.addEntryButton.rawValue)
         } // END OF TOOBAR ITEM
     }
+    
     var navigationToolbar: some ToolbarContent {
         ToolbarItem(placement: .navigationBarTrailing) {
             NavigationLink{
@@ -106,6 +114,7 @@ struct HistoryView: View {
             .tint(.primary)
         }
     }
+    
     var searchBar: some View {
         Section {
             HStack {
@@ -114,8 +123,11 @@ struct HistoryView: View {
             }
         }
     }
-} // END OF STRUCT
-
+    
+    var background: some View {
+        BackgroundFactory.buildSolidColor()
+    }
+}
 
 struct HistoryView_Previews: PreviewProvider {
     private struct ContainerView: View {

--- a/ClockIn/View/HistoryView.swift
+++ b/ClockIn/View/HistoryView.swift
@@ -34,9 +34,6 @@ struct HistoryView: View {
             List {
                 searchBar
                 makeListConent(viewModel.groupedEntries)
-                if viewModel.isMoreEntriesAvaliable {
-                    lastRow
-                }
             } // END OF LIST
             .scrollContentBackground(.hidden)
             .sheet(item: $selectedEntry) { entry in
@@ -53,6 +50,7 @@ struct HistoryView: View {
         .navigationTitle(navigationTitleText)
         .navigationBarTitleDisplayMode(.inline)
     } // END OF BODY
+    
     func makeSectionHeader(_ entry: Entry?) -> String {
         if let date = entry?.startDate {
             return headerFormatter.string(from: date)
@@ -90,16 +88,21 @@ extension HistoryView {
     func makeListSection(_ entries: [Entry]) -> some View {
         Section(makeSectionHeader(entries.first)) {
             ForEach(entries) { entry in
-                HistoryRowViewPrototype(startDate: entry.startDate,
-                                        finishDate: entry.finishDate,
-                                        workTime: viewModel.convertWorkTimeToFraction(entry: entry),
-                                        overTime: viewModel.convertOvertimeToFraction(entry: entry),
-                                        timeWorked: viewModel.timeWorkedLabel(for: entry))
-                .accessibilityIdentifier(Identifier.entryRow.rawValue)
-                .swipeActions {
-                    makeDeleteButton(entry)
-                    makeEditButton(entry)
-                } // END OF SWIPE ACTIONS
+                VStack {
+                    HistoryRowViewPrototype(startDate: entry.startDate,
+                                            finishDate: entry.finishDate,
+                                            workTime: viewModel.convertWorkTimeToFraction(entry: entry),
+                                            overTime: viewModel.convertOvertimeToFraction(entry: entry),
+                                            timeWorked: makeTimeWorkedLabel(entry))
+                    .accessibilityIdentifier(Identifier.entryRow.rawValue)
+                    .swipeActions {
+                        makeDeleteButton(entry)
+                        makeEditButton(entry)
+                    } // END OF SWIPE ACTIONS
+                    if isLastEntry(entry) && viewModel.isMoreEntriesAvaliable {
+                        lastRow
+                    }
+                }
             }
         }
     }

--- a/ClockIn/View/HistoryView.swift
+++ b/ClockIn/View/HistoryView.swift
@@ -11,6 +11,12 @@ import Charts
 struct HistoryView: View {
     private typealias Identifier = ScreenIdentifier.HistoryView
     let navigationTitleText: String = "History"
+    let headerFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter
+    }()
+    
     @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject private var container: Container
     @StateObject private var viewModel: HistoryViewModel
@@ -46,6 +52,13 @@ struct HistoryView: View {
         .navigationTitle(navigationTitleText)
         .navigationBarTitleDisplayMode(.inline)
     } // END OF BODY
+    func makeSectionHeader(_ entry: Entry?) -> String {
+        if let date = entry?.startDate {
+            return headerFormatter.string(from: date)
+        } else {
+            return String()
+        }
+    }
 } // END OF STRUCT
 
 //MARK: VIEW BUILDER FUNCTIONS

--- a/ClockIn/View/HistoryView.swift
+++ b/ClockIn/View/HistoryView.swift
@@ -33,16 +33,17 @@ struct HistoryView: View {
             // CONTENT LAYER
             List {
                 searchBar
-                makeListConent(viewModel.entries)
+                makeListConent(viewModel.groupedEntries)
                 if viewModel.isMoreEntriesAvaliable {
                     lastRow
                 }
             } // END OF LIST
             .scrollContentBackground(.hidden)
             .sheet(item: $selectedEntry) { entry in
-                EditSheetView(viewModel: EditSheetViewModel(dataManager: container.dataManager,
-                                                            settingsStore: container.settingsStore,
-                                                            entry: entry))
+                EditSheetView(viewModel: 
+                                EditSheetViewModel(dataManager: container.dataManager,
+                                                   settingsStore: container.settingsStore,
+                                                   entry: entry))
             } // END OF SHEET
         } // END OF ZSTACK
         .toolbar {
@@ -64,19 +65,27 @@ struct HistoryView: View {
 //MARK: VIEW BUILDER FUNCTIONS
 extension HistoryView {
     @ViewBuilder
-    func makeListConent(_ entries: [Entry]) -> some View {
-        ForEach(entries) { entry in
-            HistoryRowViewPrototype(startDate: entry.startDate,
-                       finishDate: entry.finishDate,
-                       workTime: viewModel.convertWorkTimeToFraction(entry: entry),
-                       overTime: viewModel.convertOvertimeToFraction(entry: entry),
-                       timeWorked: viewModel.timeWorkedLabel(for: entry))
-            .accessibilityIdentifier(Identifier.entryRow.rawValue)
-            .swipeActions {
-                makeDeleteButton(entry)
-                makeEditButton(entry)
-            } // END OF SWIPE ACTIONS
-        } // END OF FOR-EACH
+    func makeListConent(_ groupedEntries: [[Entry]]) -> some View {
+        ForEach(groupedEntries, id: \.self) { groupEntry in
+            makeListSection(groupEntry)
+        }
+    }
+    @ViewBuilder
+    func makeListSection(_ entries: [Entry]) -> some View {
+        Section(makeSectionHeader(entries.first)) {
+            ForEach(entries) { entry in
+                HistoryRowViewPrototype(startDate: entry.startDate,
+                                        finishDate: entry.finishDate,
+                                        workTime: viewModel.convertWorkTimeToFraction(entry: entry),
+                                        overTime: viewModel.convertOvertimeToFraction(entry: entry),
+                                        timeWorked: viewModel.timeWorkedLabel(for: entry))
+                .accessibilityIdentifier(Identifier.entryRow.rawValue)
+                .swipeActions {
+                    makeDeleteButton(entry)
+                    makeEditButton(entry)
+                } // END OF SWIPE ACTIONS
+            }
+        }
     }
     
     @ViewBuilder

--- a/ClockIn/View/HistoryView.swift
+++ b/ClockIn/View/HistoryView.swift
@@ -28,6 +28,9 @@ struct HistoryView: View {
             List {
                 searchBar
                 makeListConent(viewModel.entries)
+                if viewModel.isMoreEntriesAvaliable {
+                    lastRow
+                }
             } // END OF LIST
             .scrollContentBackground(.hidden)
             .sheet(item: $selectedEntry) { entry in
@@ -121,6 +124,24 @@ extension HistoryView {
                 TextField("", text: .constant(String()), prompt: Text("Search"))
                 Image(systemName: "calendar")
             }
+        }
+    }
+    
+    var lastRow: some View {
+        ZStack(alignment: .center) {
+            switch viewModel.paginationState {
+            case .isLoading:
+                ProgressView()
+                    .frame(height: 50)
+                    .frame(maxWidth: .infinity)
+            case .idle:
+                EmptyView()
+            case .error:
+                Text("Something went wrong")
+            }
+        }
+        .onAppear {
+            viewModel.loadMoreItems()
         }
     }
     

--- a/ClockIn/ViewModel/HistoryViewModel.swift
+++ b/ClockIn/ViewModel/HistoryViewModel.swift
@@ -50,18 +50,6 @@ class HistoryViewModel: ObservableObject {
         self.groupedEntries = loadInitialEntries()
     }
     
-    /// provide a formatted string describing the amount of hours between start and finish date in an Entry object
-    func timeWorkedLabel(for entry: Entry) -> String {
-        
-        let sumWorkedInSec = entry.workTimeInSeconds + entry.overTimeInSeconds
-        let hours = sumWorkedInSec / 3600
-        let minutes = (sumWorkedInSec % 3600) / 60
-        
-        let hoursString = hours > 9 ? "\(hours)" : "0\(hours)"
-        let minutesString = minutes > 9 ? "\(minutes)" : "0\(minutes)"
-        
-        return "\(hoursString) hours \(minutesString) minutes"
-    }
     
     ///Converts overtime value in seconds to a fraction of the current user maximum for overtime
     ///Value return is between 0 and 1

--- a/ClockIn/ViewModel/HistoryViewModel.swift
+++ b/ClockIn/ViewModel/HistoryViewModel.swift
@@ -12,7 +12,7 @@ import Combine
 class HistoryViewModel: ObservableObject {
     @Published private var dataManager: DataManager
     @Published var paginationState: PaginationState = .idle
-    @Published var isMoreEntriesAvaliable: Bool = true
+    @Published var isMoreEntriesAvaliable: Bool = false
     
     @Published var groupedEntries: [[Entry]] = []
     
@@ -33,6 +33,7 @@ class HistoryViewModel: ObservableObject {
         dataManager.objectWillChange.sink(receiveValue: { [weak self] _ in
             self?.objectWillChange.send()
         }).store(in: &subscriptions)
+        
         self.$groupedEntries
             .map { [weak self] array in
                 guard let self,

--- a/ClockIn/ViewModel/HistoryViewModel.swift
+++ b/ClockIn/ViewModel/HistoryViewModel.swift
@@ -12,6 +12,9 @@ import Combine
 class HistoryViewModel: ObservableObject {
     
     @Published private var dataManager: DataManager
+    @Published var paginationState: PaginationState = .idle
+    @Published var isMoreEntriesAvaliable: Bool
+    
     private var settingsStore: SettingsStore
     private var maximumOvertimeInSeconds: Int {
         settingsStore.maximumOvertimeAllowedInSeconds
@@ -25,14 +28,17 @@ class HistoryViewModel: ObservableObject {
     init(dataManager: DataManager, settingsStore: SettingsStore) {
         self.dataManager = dataManager
         self.settingsStore = settingsStore
+        self.isMoreEntriesAvaliable = {
+           return true
+        }()
+        self.entries = dataManager.entryThisMonth
+        
         dataManager.objectWillChange.sink(receiveValue: { [weak self] _ in
             self?.objectWillChange.send()
         }).store(in: &subscriptions)
     }
     
-    var entries: [Entry] {
-        dataManager.entryArray
-    }
+    var entries: [Entry]
     
     /// provide a formatted string describing the amount of hours between start and finish date in an Entry object
     func timeWorkedLabel(for entry: Entry) -> String {
@@ -69,6 +75,12 @@ class HistoryViewModel: ObservableObject {
     
     func updateAndSave(entry: Entry) {
         dataManager.updateAndSave(entry: entry)
+    }
+    
+    func loadMoreItems() {
+        print("loading more items")
+        paginationState = .isLoading
+        print("Entries this month: \(dataManager.entryThisMonth.count)")
     }
 }
  

--- a/ClockIn/ViewModel/HistoryViewModel.swift
+++ b/ClockIn/ViewModel/HistoryViewModel.swift
@@ -10,7 +10,6 @@ import CoreData
 import Combine
 
 class HistoryViewModel: ObservableObject {
-    
     @Published private var dataManager: DataManager
     @Published var paginationState: PaginationState = .idle
     @Published var isMoreEntriesAvaliable: Bool
@@ -32,13 +31,41 @@ class HistoryViewModel: ObservableObject {
            return true
         }()
         self.entries = dataManager.entryThisMonth
-        
+        self.groupedEntries = groupEntriesByYearMonth(dataManager.entryArray)
         dataManager.objectWillChange.sink(receiveValue: { [weak self] _ in
             self?.objectWillChange.send()
         }).store(in: &subscriptions)
     }
     
     var entries: [Entry]
+    
+    var groupedEntries: [[Entry]] = []
+        
+    
+    func groupEntriesByYearMonth(_ entries: [Entry]) -> [[Entry]] {
+        var result: [[Entry]] = .init()
+        
+        var currentYearMonth: DateComponents?
+        var currentEntries: [Entry] = .init()
+        
+        for entry in dataManager.entryArray {
+            let entryDateComponents = Calendar.current.dateComponents([.month,.year], from: entry.startDate)
+            if entryDateComponents != currentYearMonth {
+                if !currentEntries.isEmpty {
+                    result.append(currentEntries)
+                }
+                currentEntries = [entry]
+                currentYearMonth = entryDateComponents
+            } else {
+                currentEntries.append(entry)
+            }
+        }
+        if !currentEntries.isEmpty {
+            result.append(currentEntries)
+        }
+            
+        return result
+    }
     
     /// provide a formatted string describing the amount of hours between start and finish date in an Entry object
     func timeWorkedLabel(for entry: Entry) -> String {


### PR DESCRIPTION
In this PR the history view and its view model was reworked to display all of the historical data with pagination for the results. The displayed data was changed from being statically retrieved from data manager published array of entries into being fetched to history view model. Additionally a prototype for search field was added and entries were grouped into sections based on months. 

I modified:
- HistoryView
- HistoryViewModel
- DataManager

Added:
- PaginationState enum