### PR TITLE
Add filtering by date in history view

### DIFF
--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		D68732022B2243C9008CB0D4 /* PaginationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68732012B2243C9008CB0D4 /* PaginationState.swift */; };
 		D6AB737029F562E600D5DE82 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AB736F29F562E600D5DE82 /* OnboardingViewModel.swift */; };
 		D6B2BDF22B27810700CB4FA7 /* DateFilterSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B2BDF12B27810700CB4FA7 /* DateFilterSheetView.swift */; };
+		D6B2BDF42B27C22400CB4FA7 /* EmptyPlaceholderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B2BDF32B27C22400CB4FA7 /* EmptyPlaceholderModifier.swift */; };
 		D6B3B2662ABA237800101A1F /* SettingsViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B3B2652ABA237800101A1F /* SettingsViewUITests.swift */; };
 		D6B7D1C82B0EB41A00E6F7A8 /* ContentViewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B7D1C72B0EB41A00E6F7A8 /* ContentViewScreen.swift */; };
 		D6BC457E2AFAE0640030820C /* ColorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BC457D2AFAE0640030820C /* ColorTheme.swift */; };
@@ -139,6 +140,7 @@
 		D68732012B2243C9008CB0D4 /* PaginationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationState.swift; sourceTree = "<group>"; };
 		D6AB736F29F562E600D5DE82 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		D6B2BDF12B27810700CB4FA7 /* DateFilterSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DateFilterSheetView.swift; path = ClockIn/View/DateFilterSheetView.swift; sourceTree = "<group>"; };
+		D6B2BDF32B27C22400CB4FA7 /* EmptyPlaceholderModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyPlaceholderModifier.swift; sourceTree = "<group>"; };
 		D6B3B2652ABA237800101A1F /* SettingsViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewUITests.swift; sourceTree = "<group>"; };
 		D6B7D1C72B0EB41A00E6F7A8 /* ContentViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewScreen.swift; sourceTree = "<group>"; };
 		D6BC457D2AFAE0640030820C /* ColorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTheme.swift; sourceTree = "<group>"; };
@@ -239,6 +241,14 @@
 			path = OboardingViews;
 			sourceTree = "<group>";
 		};
+		D6B2BDF52B27C42800CB4FA7 /* ViewModifiers */ = {
+			isa = PBXGroup;
+			children = (
+				D6B2BDF32B27C22400CB4FA7 /* EmptyPlaceholderModifier.swift */,
+			);
+			path = ViewModifiers;
+			sourceTree = "<group>";
+		};
 		D6C4588729D229200069D89B = {
 			isa = PBXGroup;
 			children = (
@@ -263,6 +273,7 @@
 		D6C4589229D229210069D89B /* ClockIn */ = {
 			isa = PBXGroup;
 			children = (
+				D6B2BDF52B27C42800CB4FA7 /* ViewModifiers */,
 				D61F11322AB3A6E700902D6D /* Extensions */,
 				D6D906AF2AA12BBD004E09C9 /* Factory */,
 				D6E2C15629D6BF9F00229286 /* Model */,
@@ -531,6 +542,7 @@
 				D6FA94FB2B013C770034B16A /* ChartLegendItem.swift in Sources */,
 				D666ADCC2AC05A0500B74663 /* CaseIterable+Extension.swift in Sources */,
 				D65FD53D29D8B259006CC34F /* PersistanceController.swift in Sources */,
+				D6B2BDF42B27C22400CB4FA7 /* EmptyPlaceholderModifier.swift in Sources */,
 				D60480DA2B122D3F00D6D70D /* ChartPeriodService.swift in Sources */,
 				D66750EA29D713C900757F17 /* HistoryView.swift in Sources */,
 				D64313B82B1E606B003B5DBC /* PreviewDataFactory.swift in Sources */,

--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		D684A38A2AF6F54B00511E0D /* ButtonFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D684A3892AF6F54B00511E0D /* ButtonFactory.swift */; };
 		D68732022B2243C9008CB0D4 /* PaginationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68732012B2243C9008CB0D4 /* PaginationState.swift */; };
 		D6AB737029F562E600D5DE82 /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AB736F29F562E600D5DE82 /* OnboardingViewModel.swift */; };
+		D6B2BDF22B27810700CB4FA7 /* DateFilterSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B2BDF12B27810700CB4FA7 /* DateFilterSheetView.swift */; };
 		D6B3B2662ABA237800101A1F /* SettingsViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B3B2652ABA237800101A1F /* SettingsViewUITests.swift */; };
 		D6B7D1C82B0EB41A00E6F7A8 /* ContentViewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B7D1C72B0EB41A00E6F7A8 /* ContentViewScreen.swift */; };
 		D6BC457E2AFAE0640030820C /* ColorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BC457D2AFAE0640030820C /* ColorTheme.swift */; };
@@ -137,6 +138,7 @@
 		D684A3892AF6F54B00511E0D /* ButtonFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonFactory.swift; sourceTree = "<group>"; };
 		D68732012B2243C9008CB0D4 /* PaginationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationState.swift; sourceTree = "<group>"; };
 		D6AB736F29F562E600D5DE82 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
+		D6B2BDF12B27810700CB4FA7 /* DateFilterSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DateFilterSheetView.swift; path = ClockIn/View/DateFilterSheetView.swift; sourceTree = "<group>"; };
 		D6B3B2652ABA237800101A1F /* SettingsViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewUITests.swift; sourceTree = "<group>"; };
 		D6B7D1C72B0EB41A00E6F7A8 /* ContentViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewScreen.swift; sourceTree = "<group>"; };
 		D6BC457D2AFAE0640030820C /* ColorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTheme.swift; sourceTree = "<group>"; };
@@ -240,6 +242,7 @@
 		D6C4588729D229200069D89B = {
 			isa = PBXGroup;
 			children = (
+				D6B2BDF12B27810700CB4FA7 /* DateFilterSheetView.swift */,
 				D6C4589229D229210069D89B /* ClockIn */,
 				D6C458A329D229230069D89B /* ClockInTests */,
 				D6C458AD29D229230069D89B /* ClockInUITests */,
@@ -548,6 +551,7 @@
 				D6C4589429D229210069D89B /* ClockInApp.swift in Sources */,
 				D6E2C15929D6C20E00229286 /* WorkHistory.xcdatamodeld in Sources */,
 				D60EB9B62AB0D7000053136A /* Container.swift in Sources */,
+				D6B2BDF22B27810700CB4FA7 /* DateFilterSheetView.swift in Sources */,
 				D6E6B8752AF98EB40073D911 /* OnboardingSalaryView.swift in Sources */,
 				D65A976F29F3BBDD00462D8C /* OnboardingView.swift in Sources */,
 				D6842EC229EC179200731E84 /* StatisticsViewModel.swift in Sources */,

--- a/ClockIn/Extensions/View+Extension.swift
+++ b/ClockIn/Extensions/View+Extension.swift
@@ -34,4 +34,12 @@ extension View {
             self
         }
     }
+    
+    func emptyPlaceholder<Items: Collection, PlaceholderView: View>(_ items: Items, _ placeholder: @escaping () -> PlaceholderView) -> some View {
+        self.modifier(
+            EmptyPlaceholderModifier(items: items,
+                                     placeholder: AnyView(placeholder())
+                                    )
+        )
+    }
 }

--- a/ClockIn/View/DateFilterSheetView.swift
+++ b/ClockIn/View/DateFilterSheetView.swift
@@ -1,0 +1,78 @@
+//
+//  DateFilterSheet.swift
+//  ClockIn
+//
+//  Created by Tomasz Kubiak on 11/12/2023.
+//
+
+import SwiftUI
+
+struct DateFilterSheetView: View {
+    let title: String = "Filter"
+    let toLabel: String = "To:"
+    let fromLabel: String = "From:"
+    let sortLabel: String = "Oldest entries first"
+    @Environment(\.dismiss) var dismiss
+    @Binding var fromDate: Date
+    @Binding var toDate: Date
+    @Binding var sortAscending: Bool
+    let cancelAction: () -> Void
+    let confirmAction: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(title)
+                .font(.title)
+                .fontWeight(.semibold)
+            DatePicker(fromLabel, 
+                       selection: $fromDate,
+                       displayedComponents: .date)
+            DatePicker(toLabel, 
+                       selection: $toDate,
+                       displayedComponents: .date)
+            Toggle(sortLabel, isOn: $sortAscending)
+                .padding(.vertical)
+            buttonPanel
+                .frame(maxWidth: .infinity)
+        }
+        .padding(.horizontal, 32)
+    }
+    
+    var buttonPanel: some View {
+        HStack {
+            Button(role: .cancel) {
+                cancelAction()
+                dismiss()
+            } label: {
+                Text("Cancel")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            
+            Button {
+                confirmAction()
+                dismiss()
+            } label: {
+                Text("Apply")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+}
+
+#Preview {
+    Color.gray.ignoresSafeArea()
+        .popover(isPresented: .constant(true)) {
+            DateFilterSheetView(fromDate: .constant(Date()),
+                                toDate: .constant(Date()),
+                                sortAscending: .constant(true)
+            ) {
+               print("Cancel pressed")
+            } confirmAction: {
+                print("Confirm pressed")
+            }
+            
+            .presentationDetents([.fraction(0.4)])
+        }
+}

--- a/ClockIn/View/HistoryView.swift
+++ b/ClockIn/View/HistoryView.swift
@@ -11,7 +11,10 @@ import Charts
 struct HistoryView: View {
     private typealias Identifier = ScreenIdentifier.HistoryView
     let navigationTitleText: String = "History"
-    
+    let placeholderText: String = """
+                    Ooops! Something went wrong,
+                    or you never recorded time...
+                    """
     let headerFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "MMMM yyyy"
@@ -36,6 +39,9 @@ struct HistoryView: View {
             List {
                 makeListConent(viewModel.groupedEntries)
             } // END OF LIST
+            .emptyPlaceholder(viewModel.groupedEntries) {
+                emptyPlaceholderView
+            }
             .scrollContentBackground(.hidden)
             .sheet(item: $selectedEntry) { entry in
                 EditSheetView(viewModel: 
@@ -142,6 +148,14 @@ extension HistoryView {
 
 //MARK: VIEW COMPONENTS
 extension HistoryView {
+    var emptyPlaceholderView: some View {
+        VStack {
+            Image(systemName: "nosign")
+            Text(placeholderText)
+                .multilineTextAlignment(.center)
+        }
+    }
+    
     var filteringView: some View {
         DateFilterSheetView(fromDate: $viewModel.filterFromDate,
                             toDate: $viewModel.filterToDate,

--- a/ClockIn/ViewModel/HistoryViewModel.swift
+++ b/ClockIn/ViewModel/HistoryViewModel.swift
@@ -16,6 +16,9 @@ class HistoryViewModel: ObservableObject {
     
     @Published var groupedEntries: [[Entry]] = []
     
+    @Published var filterFromDate: Date = Date()
+    @Published var filterToDate: Date = Date()
+    
     private var periodService: ChartPeriodService = .init(calendar: .current)
     private var sizeOfChunk: Int = 15
     private var settingsStore: SettingsStore

--- a/ClockIn/ViewModel/HistoryViewModel.swift
+++ b/ClockIn/ViewModel/HistoryViewModel.swift
@@ -22,7 +22,7 @@ class HistoryViewModel: ObservableObject {
     @Published var isSortingActive: Bool = false
     
     private var periodService: ChartPeriodService = .init(calendar: .current)
-    private var sizeOfChunk: Int = 15
+    private var sizeOfChunk: Int?
     private var settingsStore: SettingsStore
     private var maximumOvertimeInSeconds: Int {
         settingsStore.maximumOvertimeAllowedInSeconds
@@ -32,9 +32,11 @@ class HistoryViewModel: ObservableObject {
     }
     private var subscriptions: Set<AnyCancellable> = .init()
     
-    init(dataManager: DataManager, settingsStore: SettingsStore) {
+    init(dataManager: DataManager, settingsStore: SettingsStore, sizeOfChunk: Int? = 15) {
         self.dataManager = dataManager
         self.settingsStore = settingsStore
+        self.sizeOfChunk = sizeOfChunk
+        
         dataManager.objectWillChange.sink(receiveValue: { [weak self] _ in
             self?.objectWillChange.send()
         }).store(in: &subscriptions)

--- a/ClockIn/ViewModifiers/EmptyPlaceholderModifier.swift
+++ b/ClockIn/ViewModifiers/EmptyPlaceholderModifier.swift
@@ -1,0 +1,22 @@
+//
+//  EmptyPlaceholderModifier.swift
+//  ClockIn
+//
+//  Created by Tomasz Kubiak on 11/12/2023.
+//
+
+import SwiftUI
+
+struct EmptyPlaceholderModifier<T: Collection>: ViewModifier {
+    let items: T
+    let placeholder: AnyView
+    
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if !items.isEmpty {
+            content
+        } else {
+            placeholder
+        }
+    }
+}

--- a/ClockInTests/HistoryViewModelTests.swift
+++ b/ClockInTests/HistoryViewModelTests.swift
@@ -12,12 +12,13 @@ import CoreData
 final class HistoryViewModelTests: XCTestCase {
 
     var sut: HistoryViewModel!
-    
+    var container: Container!
     
     override func setUp() {
         super.setUp()
-        sut = .init(dataManager: DataManager.testing,
-                    settingsStore: SettingsStore()
+        container = .init()
+        sut = .init(dataManager: container.dataManager,
+                    settingsStore: container.settingsStore
         )
     }
 
@@ -26,15 +27,65 @@ final class HistoryViewModelTests: XCTestCase {
         sut = nil
     }
     
-
-    func testTimeWorkedLabel_withNormalDate() {
-        let startDate = Calendar.current.date(byAdding: .hour, value: -7 , to: Date())!
-        let finishDate = Calendar.current.date(byAdding: .hour, value: 2 , to: Date())!
-        let entry = Entry(startDate: startDate, finishDate: finishDate, workTimeInSec: 8 * 3600, overTimeInSec: Int(1.5 * 3600))
+    func test_groupingEntries() {
+        sut = nil
+        let calendar = Calendar.current
+        guard let date = calendar.date(from: DateComponents(year: 2023, month: 12)) else { XCTFail(); return }
         
-        let result = sut.timeWorkedLabel(for: entry)
+        let entries = PreviewDataFactory.buildDataForPreviewForYear(containing: date, using: calendar)
         
-        XCTAssertEqual(result, "09 hours 30 minutes")
+        for entry in entries {
+            container.dataManager.updateAndSave(entry: entry)
+        }
+        
+        sut = .init(dataManager: container.dataManager,
+                    settingsStore: container.settingsStore,
+                    sizeOfChunk: nil)
+        
+        XCTAssertEqual(sut.groupedEntries.count, 12)
+        for (i, monthArray) in sut.groupedEntries.enumerated() {
+            let correctMonthNumber = i + 1
+            for entry in monthArray {
+                let monthNumber = calendar.dateComponents([.month], from: entry.startDate).month
+                XCTAssertEqual(correctMonthNumber, correctMonthNumber, "Month number should be 1 more than array index")
+            }
+        }
+    }
+    
+    func test_loadingInitialEntries() {
+        sut = nil
+        let calendar = Calendar.current
+        guard let date = calendar.date(from: DateComponents(year: 2023, month: 12)) else { XCTFail(); return }
+        
+        let entries = PreviewDataFactory.buildDataForPreviewForYear(containing: date, using: calendar)
+        
+        for entry in entries {
+            container.dataManager.updateAndSave(entry: entry)
+        }
+        let chunkSize = 15
+        sut = .init(dataManager: container.dataManager,
+                    settingsStore: container.settingsStore,
+                    sizeOfChunk: chunkSize)
+        XCTAssertEqual(sut.groupedEntries.flatMap({ $0 }).count, 15, "Number of entries should be equal to set chunk size")
+    }
+    
+    func test_LoadingMoreItems() {
+        sut = nil
+        let calendar = Calendar.current
+        guard let date = calendar.date(from: DateComponents(year: 2023, month: 12)) else { XCTFail(); return }
+        
+        let entries = PreviewDataFactory.buildDataForPreviewForYear(containing: date, using: calendar)
+        
+        for entry in entries {
+            container.dataManager.updateAndSave(entry: entry)
+        }
+        
+        let chunkSize = 15
+        sut = .init(dataManager: container.dataManager,
+                    settingsStore: container.settingsStore,
+                    sizeOfChunk: chunkSize)
+        sut.loadMoreItems()
+        XCTAssertEqual(sut.groupedEntries.flatMap({ $0 }).count, chunkSize * 2, "Number of entries should be equal to two times chunk size")
     }
     
     func testConvertOvertimeToFraction_for2hours30minutes() {

--- a/ClockInTests/HistoryViewModelTests.swift
+++ b/ClockInTests/HistoryViewModelTests.swift
@@ -25,6 +25,7 @@ final class HistoryViewModelTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         sut = nil
+        container = nil
     }
     
     func test_groupingEntries() {
@@ -88,6 +89,59 @@ final class HistoryViewModelTests: XCTestCase {
         XCTAssertEqual(sut.groupedEntries.flatMap({ $0 }).count, chunkSize * 2, "Number of entries should be equal to two times chunk size")
     }
     
+    func test_applyFilters() {
+        sut = nil
+        let calendar = Calendar.current
+        guard let date = calendar.date(from: DateComponents(year: 2023, month: 12)) else { XCTFail(); return }
+        
+        let entries = PreviewDataFactory.buildDataForPreviewForYear(containing: date, using: calendar)
+        
+        for entry in entries {
+            container.dataManager.updateAndSave(entry: entry)
+        }
+        let chunkSize = 30
+        sut = .init(dataManager: container.dataManager,
+                    settingsStore: container.settingsStore,
+                    sizeOfChunk: chunkSize)
+        guard let fromDate =  calendar.date(from: DateComponents(year: 2023, month: 11, day: 6)),
+              let toDate = calendar.date(from: DateComponents(year: 2023, month: 11, day: 11)) else {
+            XCTFail()
+            return
+        }
+        sut.filterFromDate = fromDate
+        sut.filterToDate = toDate
+        sut.applyFilters()
+        XCTAssertEqual(sut.isSortingActive, true, "Sorting shoud be active")
+        XCTAssertEqual(sut.groupedEntries.flatMap({ $0 }).count, 5, "There should be 5 entries")
+        
+    }
+    func test_resetFilters() {
+        sut = nil
+        let calendar = Calendar.current
+        guard let date = calendar.date(from: DateComponents(year: 2023, month: 12)) else { XCTFail(); return }
+        
+        let entries = PreviewDataFactory.buildDataForPreviewForYear(containing: date, using: calendar)
+        
+        for entry in entries {
+            container.dataManager.updateAndSave(entry: entry)
+        }
+        let chunkSize = 30
+        sut = .init(dataManager: container.dataManager,
+                    settingsStore: container.settingsStore,
+                    sizeOfChunk: chunkSize)
+        guard let fromDate =  calendar.date(from: DateComponents(year: 2023, month: 12, day: 4)),
+              let toDate = calendar.date(from: DateComponents(year: 2023, month: 12, day: 8)) else {
+            XCTFail()
+            return
+        }
+        sut.filterFromDate = fromDate
+        sut.filterToDate = toDate
+        sut.applyFilters()
+        
+        sut.resetFilters()
+        XCTAssertEqual(sut.groupedEntries.flatMap({ $0 }).count, chunkSize, "Number of entries should be equal to two times chunk size")
+        
+    }
     func testConvertOvertimeToFraction_for2hours30minutes() {
         let startDate = Calendar.current.date(byAdding: .hour, value: -7 , to: Date())!
         let finishDate = Calendar.current.date(byAdding: .hour, value: 2 , to: Date())!


### PR DESCRIPTION
This PR brings functionality of filtering to history view. There is a new view added as a sheet to history view, that allows user to pick two date that will change the displayed data, as well lets the user decide the order of this data. Filtering variables are in view model, together with function to run and reset filters. 

Added:
- Date filter sheet view