### PR TITLE
16 entries should retain user data from the moment of creation

### DIFF
--- a/ClockIn/Factory/PreviewDataFactory.swift
+++ b/ClockIn/Factory/PreviewDataFactory.swift
@@ -51,7 +51,11 @@ struct PreviewDataFactory {
             startDate: startDate,
             finishDate: finishDate,
             workTimeInSec: workTime,
-            overTimeInSec: overtime
+            overTimeInSec: overtime,
+            maximumOvertimeAllowedInSeconds: 5*3600,
+            standardWorktimeInSeconds: 8*3600,
+            grossPayPerMonth: 10000,
+            calculatedNetPay: nil
         )
     }
 }

--- a/ClockIn/Model/DataManager.swift
+++ b/ClockIn/Model/DataManager.swift
@@ -43,16 +43,6 @@ class DataManager: NSObject, ObservableObject {
         case .testing:
             let persistanceController = PersistanceController(inMemory: true)
             self.managedObjectContext = persistanceController.viewContext
-                var dateComponents = Calendar.current.dateComponents([.month,.year], from: Date())
-                dateComponents.day = 1
-                let date = Calendar.current.date(from: dateComponents)!
-                let entry = EntryMO(context: managedObjectContext)
-                entry.id = UUID()
-                entry.startDate = Calendar.current.date(byAdding: .hour, value: 6, to: date)!
-                entry.finishDate = Calendar.current.date(byAdding: DateComponents(hour: 14, minute: 30), to: date)!
-                entry.overTime = Int64(1 * 1800)
-                entry.workTime = 8 * 3600
-            
         }
         
         //Build FRCs
@@ -75,16 +65,23 @@ class DataManager: NSObject, ObservableObject {
         let compPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [startPredicate, finishPredicate])
         fetchRequestThisMonth.predicate = compPredicate
         
-        entryThisMonthFetchResultsController = NSFetchedResultsController(fetchRequest: fetchRequestThisMonth,
-                                                                          managedObjectContext: managedObjectContext,
-                                                                          sectionNameKeyPath: nil,
-                                                                          cacheName: nil)
+        entryThisMonthFetchResultsController = NSFetchedResultsController(
+            fetchRequest: fetchRequestThisMonth,
+            managedObjectContext: managedObjectContext,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
         
         
         super.init()
         
-        if type == .preview {
+        switch type {
+        case .normal:
+            break
+        case .preview:
             addPreviewDataFromFactory()
+        case .testing:
+            addTestingData()
         }
         
         entryFetchResultsController.delegate = self
@@ -132,6 +129,22 @@ class DataManager: NSObject, ObservableObject {
         for entry in entryToAdd {
             self.updateAndSave(entry: entry)
         }
+    }
+    
+    private func addTestingData() {
+        var dateComponents = Calendar.current.dateComponents([.month,.year], from: Date())
+        dateComponents.day = 1
+        let date = Calendar.current.date(from: dateComponents)!
+        let entry = EntryMO(context: managedObjectContext)
+        entry.id = UUID()
+        entry.startDate = Calendar.current.date(byAdding: .hour, value: 6, to: date)!
+        entry.finishDate = Calendar.current.date(byAdding: DateComponents(hour: 14, minute: 30), to: date)!
+        entry.overTime = Int64(1 * 1800)
+        entry.workTime = 8 * 3600
+        entry.maximumOvertimeAllowedInSeconds = 5 * 3600
+        entry.standardWorktimeAllowedInSeconds = 8 * 3600
+        entry.grossPayPerMonth = 10000
+        saveContext()
     }
 }
 extension DataManager: NSFetchedResultsControllerDelegate {

--- a/ClockIn/Model/DataManager.swift
+++ b/ClockIn/Model/DataManager.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreData
 
 enum DataManagerType {
-case normal, preview, testing
+    case normal, preview, testing
 }
 
 class DataManager: NSObject, ObservableObject {
@@ -19,6 +19,7 @@ class DataManager: NSObject, ObservableObject {
     static let preview = DataManager(type: .preview)
     static let testing = DataManager(type: .testing)
     
+    //TODO: THINK ABOUT REMOVING THE VALUES TO NOT GET ALL OF THE OBJECTS AT THE START OF THE APPLICATION
     //MARK: PUBLISHED PROPERTIES
     @Published var entryArray = [Entry]()
     @Published var entryThisMonth = [Entry]()
@@ -149,8 +150,7 @@ class DataManager: NSObject, ObservableObject {
 }
 extension DataManager: NSFetchedResultsControllerDelegate {
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        if controller == entryFetchResultsController { 
-            //controller.fetchRequest.predicate == nil {
+        if controller == entryFetchResultsController {
             guard let fetchedObjects = controller.fetchedObjects else { return }
             let newEntries = fetchedObjects.compactMap({$0 as? EntryMO})
             self.entryArray = newEntries.map { Entry(entryMO: $0) }

--- a/ClockIn/Model/DataManager.swift
+++ b/ClockIn/Model/DataManager.swift
@@ -142,7 +142,7 @@ class DataManager: NSObject, ObservableObject {
         entry.overTime = Int64(1 * 1800)
         entry.workTime = 8 * 3600
         entry.maximumOvertimeAllowedInSeconds = 5 * 3600
-        entry.standardWorktimeAllowedInSeconds = 8 * 3600
+        entry.standardWorktimeInSeconds = 8 * 3600
         entry.grossPayPerMonth = 10000
         saveContext()
     }
@@ -173,7 +173,7 @@ extension Entry {
         self.workTimeInSeconds = Int(entryMO.workTime)
         self.overTimeInSeconds = Int(entryMO.overTime)
         self.maximumOvertimeAllowedInSeconds = Int(entryMO.maximumOvertimeAllowedInSeconds)
-        self.standardWorktimeAllowedInSeconds = Int(entryMO.standardWorktimeAllowedInSeconds)
+        self.standardWorktimeInSeconds = Int(entryMO.standardWorktimeInSeconds)
         self.grossPayPerMonth = Int(entryMO.grossPayPerMonth)
         self.calculatedNetPay = Double(entryMO.calculatedNetPay)
     }
@@ -300,10 +300,10 @@ extension DataManager {
         entryMO.workTime = Int64(entry.workTimeInSeconds)
         entryMO.overTime = Int64(entry.overTimeInSeconds)
         entryMO.maximumOvertimeAllowedInSeconds = Int64(entry.maximumOvertimeAllowedInSeconds)
-        entryMO.standardWorktimeAllowedInSeconds = Int64(entry.standardWorktimeAllowedInSeconds)
+        entryMO.standardWorktimeInSeconds = Int64(entry.standardWorktimeInSeconds)
         entryMO.grossPayPerMonth = Int64(entry.grossPayPerMonth)
         if let netPay = entry.calculatedNetPay {
-            entryMO.calculatedNetPay = Int64(netPay)
+            entryMO.calculatedNetPay = Double(netPay)
         }
     }
 }

--- a/ClockIn/Model/DataManager.swift
+++ b/ClockIn/Model/DataManager.swift
@@ -159,6 +159,10 @@ extension Entry {
         self.finishDate = entryMO.finishDate
         self.workTimeInSeconds = Int(entryMO.workTime)
         self.overTimeInSeconds = Int(entryMO.overTime)
+        self.maximumOvertimeAllowedInSeconds = Int(entryMO.maximumOvertimeAllowedInSeconds)
+        self.standardWorktimeAllowedInSeconds = Int(entryMO.standardWorktimeAllowedInSeconds)
+        self.grossPayPerMonth = Int(entryMO.grossPayPerMonth)
+        self.calculatedNetPay = Int(entryMO.calculatedNetPay)
     }
 }
 
@@ -282,5 +286,11 @@ extension DataManager {
         entryMO.finishDate = entry.finishDate
         entryMO.workTime = Int64(entry.workTimeInSeconds)
         entryMO.overTime = Int64(entry.overTimeInSeconds)
+        entryMO.maximumOvertimeAllowedInSeconds = Int64(entry.maximumOvertimeAllowedInSeconds)
+        entryMO.standardWorktimeAllowedInSeconds = Int64(entry.standardWorktimeAllowedInSeconds)
+        entryMO.grossPayPerMonth = Int64(entry.grossPayPerMonth)
+        if let netPay = entry.calculatedNetPay {
+            entryMO.calculatedNetPay = Int64(netPay)
+        }
     }
 }

--- a/ClockIn/Model/DataManager.swift
+++ b/ClockIn/Model/DataManager.swift
@@ -175,7 +175,7 @@ extension Entry {
         self.maximumOvertimeAllowedInSeconds = Int(entryMO.maximumOvertimeAllowedInSeconds)
         self.standardWorktimeAllowedInSeconds = Int(entryMO.standardWorktimeAllowedInSeconds)
         self.grossPayPerMonth = Int(entryMO.grossPayPerMonth)
-        self.calculatedNetPay = Int(entryMO.calculatedNetPay)
+        self.calculatedNetPay = Double(entryMO.calculatedNetPay)
     }
 }
 

--- a/ClockIn/Model/Entry.swift
+++ b/ClockIn/Model/Entry.swift
@@ -16,7 +16,7 @@ struct Entry: Identifiable, Hashable {
     var workTimeInSeconds: Int
     var overTimeInSeconds: Int
     var maximumOvertimeAllowedInSeconds: Int
-    var standardWorktimeAllowedInSeconds: Int
+    var standardWorktimeInSeconds: Int
     var grossPayPerMonth: Int
     var calculatedNetPay: Double?
     
@@ -25,7 +25,7 @@ struct Entry: Identifiable, Hashable {
          workTimeInSec: Int,
          overTimeInSec: Int,
          maximumOvertimeAllowedInSeconds: Int,
-         standardWorktimeAllowedInSeconds: Int,
+         standardWorktimeInSeconds: Int,
          grossPayPerMonth: Int,
          calculatedNetPay: Double?) {
         self.id = UUID()
@@ -34,13 +34,13 @@ struct Entry: Identifiable, Hashable {
         self.workTimeInSeconds = workTimeInSec
         self.overTimeInSeconds = overTimeInSec
         self.maximumOvertimeAllowedInSeconds = maximumOvertimeAllowedInSeconds
-        self.standardWorktimeAllowedInSeconds = standardWorktimeAllowedInSeconds
+        self.standardWorktimeInSeconds = standardWorktimeInSeconds
         self.grossPayPerMonth = grossPayPerMonth
         self.calculatedNetPay = calculatedNetPay
     }
     
     ///Initialize with current date for start and finish, work time and overtime is set to 0
     init() {
-        self.init(startDate: Date(), finishDate: Date(), workTimeInSec: 0, overTimeInSec: 0, maximumOvertimeAllowedInSeconds: 0, standardWorktimeAllowedInSeconds: 0, grossPayPerMonth: 0, calculatedNetPay: nil)
+        self.init(startDate: Date(), finishDate: Date(), workTimeInSec: 0, overTimeInSec: 0, maximumOvertimeAllowedInSeconds: 0, standardWorktimeInSeconds: 0, grossPayPerMonth: 0, calculatedNetPay: nil)
     }
 }

--- a/ClockIn/Model/Entry.swift
+++ b/ClockIn/Model/Entry.swift
@@ -20,7 +20,14 @@ struct Entry: Identifiable, Hashable {
     var grossPayPerMonth: Int
     var calculatedNetPay: Double?
     
-    init(startDate: Date, 
+    var overtimeFraction: CGFloat {
+        CGFloat(overTimeInSeconds) / CGFloat(maximumOvertimeAllowedInSeconds)
+    }
+    var worktimeFraction: CGFloat {
+        CGFloat(workTimeInSeconds) / CGFloat(standardWorktimeInSeconds)
+    }
+    
+    init(startDate: Date,
          finishDate: Date,
          workTimeInSec: Int,
          overTimeInSec: Int,

--- a/ClockIn/Model/Entry.swift
+++ b/ClockIn/Model/Entry.swift
@@ -18,7 +18,7 @@ struct Entry: Identifiable, Hashable {
     var maximumOvertimeAllowedInSeconds: Int
     var standardWorktimeAllowedInSeconds: Int
     var grossPayPerMonth: Int
-    var calculatedNetPay: Int?
+    var calculatedNetPay: Double?
     
     init(startDate: Date, 
          finishDate: Date,
@@ -27,7 +27,7 @@ struct Entry: Identifiable, Hashable {
          maximumOvertimeAllowedInSeconds: Int,
          standardWorktimeAllowedInSeconds: Int,
          grossPayPerMonth: Int,
-         calculatedNetPay: Int?) {
+         calculatedNetPay: Double?) {
         self.id = UUID()
         self.startDate = startDate
         self.finishDate = finishDate

--- a/ClockIn/Model/Entry.swift
+++ b/ClockIn/Model/Entry.swift
@@ -15,17 +15,32 @@ struct Entry: Identifiable, Hashable {
     var finishDate: Date
     var workTimeInSeconds: Int
     var overTimeInSeconds: Int
+    var maximumOvertimeAllowedInSeconds: Int
+    var standardWorktimeAllowedInSeconds: Int
+    var grossPayPerMonth: Int
+    var calculatedNetPay: Int?
     
-    init(startDate: Date, finishDate: Date, workTimeInSec: Int, overTimeInSec: Int) {
+    init(startDate: Date, 
+         finishDate: Date,
+         workTimeInSec: Int,
+         overTimeInSec: Int,
+         maximumOvertimeAllowedInSeconds: Int,
+         standardWorktimeAllowedInSeconds: Int,
+         grossPayPerMonth: Int,
+         calculatedNetPay: Int?) {
         self.id = UUID()
         self.startDate = startDate
         self.finishDate = finishDate
         self.workTimeInSeconds = workTimeInSec
         self.overTimeInSeconds = overTimeInSec
+        self.maximumOvertimeAllowedInSeconds = maximumOvertimeAllowedInSeconds
+        self.standardWorktimeAllowedInSeconds = standardWorktimeAllowedInSeconds
+        self.grossPayPerMonth = grossPayPerMonth
+        self.calculatedNetPay = calculatedNetPay
     }
     
     ///Initialize with current date for start and finish, work time and overtime is set to 0
     init() {
-        self.init(startDate: Date(), finishDate: Date(), workTimeInSec: 0, overTimeInSec: 0)
+        self.init(startDate: Date(), finishDate: Date(), workTimeInSec: 0, overTimeInSec: 0, maximumOvertimeAllowedInSeconds: 0, standardWorktimeAllowedInSeconds: 0, grossPayPerMonth: 0, calculatedNetPay: nil)
     }
 }

--- a/ClockIn/Model/EntryMO+CoreDataProperties.swift
+++ b/ClockIn/Model/EntryMO+CoreDataProperties.swift
@@ -21,7 +21,10 @@ extension EntryMO {
     @NSManaged public var startDate: Date
     @NSManaged public var workTime: Int64
     @NSManaged public var id: UUID
-
+    @NSManaged public var maximumOvertimeAllowedInSeconds: Int64
+    @NSManaged public var standardWorktimeAllowedInSeconds: Int64
+    @NSManaged public var grossPayPerMonth: Int64
+    @NSManaged public var calculatedNetPay: Int64
 }
 
 extension EntryMO : Identifiable {

--- a/ClockIn/Model/EntryMO+CoreDataProperties.swift
+++ b/ClockIn/Model/EntryMO+CoreDataProperties.swift
@@ -24,7 +24,7 @@ extension EntryMO {
     @NSManaged public var maximumOvertimeAllowedInSeconds: Int64
     @NSManaged public var standardWorktimeAllowedInSeconds: Int64
     @NSManaged public var grossPayPerMonth: Int64
-    @NSManaged public var calculatedNetPay: Int64
+    @NSManaged public var calculatedNetPay: Double
 }
 
 extension EntryMO : Identifiable {

--- a/ClockIn/Model/EntryMO+CoreDataProperties.swift
+++ b/ClockIn/Model/EntryMO+CoreDataProperties.swift
@@ -22,7 +22,7 @@ extension EntryMO {
     @NSManaged public var workTime: Int64
     @NSManaged public var id: UUID
     @NSManaged public var maximumOvertimeAllowedInSeconds: Int64
-    @NSManaged public var standardWorktimeAllowedInSeconds: Int64
+    @NSManaged public var standardWorktimeInSeconds: Int64
     @NSManaged public var grossPayPerMonth: Int64
     @NSManaged public var calculatedNetPay: Double
 }

--- a/ClockIn/Model/PayManager.swift
+++ b/ClockIn/Model/PayManager.swift
@@ -71,28 +71,40 @@ class PayManager: ObservableObject {
 }
 //MARK: CALENDAR FUNCTIONS
 extension PayManager {
-    func getNumberOfWorkingDays(inMonthOfDate date: Date = Date()) -> Int {
-        let components = Calendar.current.dateComponents([.month, .year], from: date)
-        let startOfTheMonth = Calendar.current.date(from: components)!
-        let numberOfDays = Calendar.current.range(of: .day, in: .month, for: startOfTheMonth)!.count
+    /// Get the number of working days in month containing given date
+    /// - Parameters:
+    ///   - calendar: calendar used for calculation
+    ///   - date: date contained in month
+    /// - Returns: number of working days in month
+    ///
+    /// Function checks for weekend days only. Holidays are counting as working days, as they are normally paid as standard length working days. Default calendar used is the current instance of calendar, while default date is now.
+    func getNumberOfWorkingDays(using calendar: Calendar = .current, inMonthOfDate date: Date = Date()) -> Int {
+        let components = calendar.dateComponents([.month, .year], from: date)
+        let startOfTheMonth = calendar.date(from: components)!
+        let numberOfDays = calendar.range(of: .day, in: .month, for: startOfTheMonth)!.count
         let daysInMonth = Array(0..<numberOfDays).map { i in
-            Calendar.current.date(byAdding: .day, value: i, to: startOfTheMonth)!
+            calendar.date(byAdding: .day, value: i, to: startOfTheMonth)!
         }
-        let workDays = daysInMonth.filter({!Calendar.current.isDateInWeekend($0)})
+        let workDays = daysInMonth.filter({ !calendar.isDateInWeekend($0) })
         return workDays.count
     }
     
-    func getNumberOfWorkingDaysPassed(till date: Date = Date()) -> Int {
+    /// Get the number of working days passed since begining of the month
+    /// - Parameters:
+    ///   - calendar: calendar used for calculation
+    ///   - date: date until which working days are counted
+    /// - Returns: number of working days passed
+    func getNumberOfWorkingDaysPassed(using calendar: Calendar = .current, till date: Date = Date()) -> Int {
         // calculate how many working days already passed
-        let components = Calendar.current.dateComponents([.month, .year], from: date)
-        let startOfTheMonth = Calendar.current.date(from: components)!
+        let components = calendar.dateComponents([.month, .year], from: date)
+        let startOfTheMonth = calendar.date(from: components)!
         
-        guard let numberOfDays = Calendar.current.dateComponents([.day], from: startOfTheMonth, to: date).day else { return 0 }
+        guard let numberOfDays = calendar.dateComponents([.day], from: startOfTheMonth, to: date).day else { return 0 }
         
         let daysPassed = Array(0..<numberOfDays).map { i in
-            Calendar.current.date(byAdding: .day, value: i, to: startOfTheMonth)!
+            calendar.date(byAdding: .day, value: i, to: startOfTheMonth)!
         }
-        let workDaysPassed = daysPassed.filter({ !Calendar.current.isDateInWeekend($0) })
+        let workDaysPassed = daysPassed.filter({ !calendar.isDateInWeekend($0) })
         
         return workDaysPassed.count
     }
@@ -100,8 +112,12 @@ extension PayManager {
 
 //MARK: GROSS PAY FUNCTIONS
 extension PayManager {
+    
+    /// Calculate predicted gross pay in a month based on current work hours and pay
+    /// - Returns: hypothetical gross pay
+    ///
+    /// Calculates predicted gross pay based on the amount of already earned pay and number of working days already passed. Simple linear extrapolation is used for prediction.
     func calculatePredictedGrossPay() -> Double {
-        
         let numberOfWorkingDays = getNumberOfWorkingDays()
         let numberOfWorkingDaysPassed = getNumberOfWorkingDaysPassed()
         
@@ -111,7 +127,14 @@ extension PayManager {
         
         return grossToDate * multiplier
     }
-    /// Calculate gross pay based on the saved entries in the time span given. If either of parameters is nil, gross pay for this month will be calculated
+    
+    /// Calculate gross pay based on the saved entries in the time span given.
+    /// - Parameters:
+    ///   - from: starting date for the entries included in calculation
+    ///   - to: finish date for the entries included in calculation
+    /// - Returns: gross pay erned in the given period
+    ///
+    ///  If either of parameters is nil, gross pay for this month will be calculated. Overtime extra pay is not considered for this calculation
     func calculateGrossPay(from: Date? = nil, to: Date? = nil) -> Double {
         var sumAllTimeWorkedInSec = Int()
         guard let startDate = from, let finishDate = to else {
@@ -137,6 +160,33 @@ extension PayManager {
         return 0
     }
     
+    /// Calculate gross pay for given entry
+    /// - Parameter entry: entry for which the gross pay is calculated
+    /// - Returns: gross pay amount
+    ///
+    /// Function returns gross pay for given entry based on the time work, overtime worked, and gross pay per month set for the entry. Included overtime pay coefficient of 0.5 extra for overtime.
+    func calculateGrossPayFor(entry: Entry) -> Double {
+        let overtimePayCoef = 0.5
+        let numberOfWorkingHours = Double(getNumberOfWorkingDays(inMonthOfDate: entry.startDate) * 8)
+        let payPerHour = Double(entry.grossPayPerMonth) / numberOfWorkingHours
+        let numberOfWorktimeHours = Double(entry.workTimeInSeconds) / 3600.0
+        let numberOfOvertimeHours = Double(entry.overTimeInSeconds) / 3600.0
+        return payPerHour * (numberOfWorkingHours + overtimePayCoef * numberOfOvertimeHours)
+    }
+    
+    /// Calculate gross pay per hour for given entry
+    /// - Parameter entry: entry for which to perform calculation
+    /// - Returns: gross pay per hour
+    ///
+    /// Calculate gross pay per hour based on the provided entry, The gross pay per month stored in entry is used, with the number of working days in month retrived based on entry start date.
+    func calculateGrossPayPerHour(for entry: Entry) -> Double {
+        let numberOfWorkingHours = Double(getNumberOfWorkingDays(inMonthOfDate: entry.startDate) * 8)
+        let payPerHour = Double(entry.grossPayPerMonth) / numberOfWorkingHours
+        return payPerHour
+    }
+    
+    /// Calculate gross pay per hour in the current mont based on current set gross pay per month
+    /// - Returns: gross pay per hour
     func calculateGrossPayPerHour() -> Double {
         let numberOfWorkHours = Double(getNumberOfWorkingDays() * 8)
         return grossPayPerMonth / numberOfWorkHours

--- a/ClockIn/View/ContentView.swift
+++ b/ClockIn/View/ContentView.swift
@@ -17,7 +17,8 @@ struct ContentView: View {
             NavigationView {
                 HomeView(viewModel:
                             HomeViewModel(dataManager: container.dataManager,
-                                          settingsStore: container.settingsStore,
+                                          settingsStore: container.settingsStore, 
+                                          payManager: container.payManager,
                                           timerProvider: container.timerProvider)
                 )
             }

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -146,10 +146,14 @@ struct EditSheetView_Previews: PreviewProvider {
             let startOfDay = Calendar.current.startOfDay(for: Date())
             let startDate = Calendar.current.date(byAdding: .hour, value: 6, to: startOfDay)!
             let finishDate = Calendar.current.date(byAdding: .hour, value: 9, to: startDate)!
-            return Entry(startDate: startDate,
+            return Entry(startDate: startDate, 
                          finishDate: finishDate,
                          workTimeInSec: 8*3600,
-                         overTimeInSec: 1*3600)
+                         overTimeInSec: 3600,
+                         maximumOvertimeAllowedInSeconds: 5*3600,
+                         standardWorktimeInSeconds: 8*3600,
+                         grossPayPerMonth: 10000,
+                         calculatedNetPay: nil)
         }()
         var body: some View {
             ZStack {

--- a/ClockIn/View/HistoryView.swift
+++ b/ClockIn/View/HistoryView.swift
@@ -103,8 +103,8 @@ extension HistoryView {
                 VStack {
                     HistoryRowViewPrototype(startDate: entry.startDate,
                                             finishDate: entry.finishDate,
-                                            workTime: viewModel.convertWorkTimeToFraction(entry: entry),
-                                            overTime: viewModel.convertOvertimeToFraction(entry: entry),
+                                            workTime: entry.worktimeFraction,
+                                            overTime: entry.overtimeFraction,
                                             timeWorked: makeTimeWorkedLabel(entry))
                     .accessibilityIdentifier(Identifier.entryRow.rawValue)
                     .onLongPressGesture(perform: {

--- a/ClockIn/View/HomeView.swift
+++ b/ClockIn/View/HomeView.swift
@@ -133,6 +133,7 @@ struct Home_Previews: PreviewProvider {
             NavigationView {
                 HomeView(viewModel: HomeViewModel(dataManager: container.dataManager,
                                                   settingsStore: container.settingsStore,
+                                                  payManager: container.payManager,
                                                   timerProvider: container.timerProvider))
             }
             .environmentObject(Container())

--- a/ClockIn/ViewModel/HistoryViewModel.swift
+++ b/ClockIn/ViewModel/HistoryViewModel.swift
@@ -9,36 +9,32 @@ import Foundation
 import CoreData
 import Combine
 
-class HistoryViewModel: ObservableObject {
+final class HistoryViewModel: ObservableObject {
     @Published private var dataManager: DataManager
+    private var settingsStore: SettingsStore
+    private var periodService: ChartPeriodService = .init(calendar: .current)
+    private var sizeOfChunk: Int?
+    private var subscriptions: Set<AnyCancellable> = .init()
+    @Published var groupedEntries: [[Entry]] = []
     @Published var paginationState: PaginationState = .idle
     @Published var isMoreEntriesAvaliable: Bool = false
-    
-    @Published var groupedEntries: [[Entry]] = []
-    
     @Published var filterFromDate: Date = Date()
     @Published var filterToDate: Date = Date()
     @Published var sortAscending: Bool = false
     @Published var isSortingActive: Bool = false
-    
-    private var periodService: ChartPeriodService = .init(calendar: .current)
-    private var sizeOfChunk: Int?
-    private var settingsStore: SettingsStore
-    private var maximumOvertimeInSeconds: Int {
-        settingsStore.maximumOvertimeAllowedInSeconds
-    }
-    private var scheduledWorkTimeInSeconds: Int {
-        settingsStore.workTimeInSeconds
-    }
-    private var subscriptions: Set<AnyCancellable> = .init()
     
     init(dataManager: DataManager, settingsStore: SettingsStore, sizeOfChunk: Int? = 15) {
         self.dataManager = dataManager
         self.settingsStore = settingsStore
         self.sizeOfChunk = sizeOfChunk
         
-        dataManager.objectWillChange.sink(receiveValue: { [weak self] _ in
-            self?.objectWillChange.send()
+        dataManager.objectWillChange.sink(receiveValue: { [weak self] value in
+            guard let self else { return }
+            if !self.isSortingActive {
+                self.groupedEntries = self.loadInitialEntries()
+            } else {
+                self.applyFilters()
+            }
         }).store(in: &subscriptions)
         
         self.$groupedEntries

--- a/ClockIn/ViewModel/HistoryViewModel.swift
+++ b/ClockIn/ViewModel/HistoryViewModel.swift
@@ -62,23 +62,6 @@ class HistoryViewModel: ObservableObject {
         self.groupedEntries = loadInitialEntries()
     }
     
-    
-    ///Converts overtime value in seconds to a fraction of the current user maximum for overtime
-    ///Value return is between 0 and 1
-    ///If the maximum overtime value retrived is equal to 0, the return will be 1
-    func convertOvertimeToFraction(entry: Entry) -> CGFloat {
-        guard maximumOvertimeInSeconds != 0 else { return 1 }
-        return CGFloat(entry.overTimeInSeconds) / CGFloat(maximumOvertimeInSeconds)
-    }
-    
-    ///Converts work time value in seconds to a fraction of the current user normal workday
-    ///Value returned is between 0 and 1
-    ///If the maximum overtime value retrived is equal to 0, the return will be 1
-    func convertWorkTimeToFraction(entry: Entry) -> CGFloat {
-        guard scheduledWorkTimeInSeconds != 0 else { return 1 }
-        return CGFloat(entry.workTimeInSeconds) / CGFloat(scheduledWorkTimeInSeconds)
-    }
-    
     func deleteEntry(entry: Entry) {
         dataManager.delete(entry: entry)
     }

--- a/ClockIn/ViewModel/HomeViewModel.swift
+++ b/ClockIn/ViewModel/HomeViewModel.swift
@@ -237,7 +237,7 @@ extension HomeViewModel {
                                 workTimeInSec: workTimeInSeconds,
                                 overTimeInSec: overTimeInSeconds,
                                 maximumOvertimeAllowedInSeconds: settingsStore.maximumOvertimeAllowedInSeconds,
-                                standardWorktimeAllowedInSeconds: settingsStore.workTimeInSeconds,
+                                standardWorktimeInSeconds: settingsStore.workTimeInSeconds,
                                 grossPayPerMonth: settingsStore.grossPayPerMonth, calculatedNetPay: calculatedNetPay)
         dataManager.updateAndSave(entry: entryToSave)
     }

--- a/ClockIn/ViewModel/HomeViewModel.swift
+++ b/ClockIn/ViewModel/HomeViewModel.swift
@@ -13,6 +13,7 @@ class HomeViewModel: NSObject, ObservableObject {
     //MARK: DATA MANAGING PROPERTIES
     private var dataManager: DataManager
     private var settingsStore: SettingsStore
+    private var payManager: PayManager
     private var startDate: Date?
     private var finishDate: Date?
     private var subscriptions = Set<AnyCancellable>()
@@ -58,10 +59,11 @@ class HomeViewModel: NSObject, ObservableObject {
     //MARK: BACKGROUND TIMER HANDLING PROPERTIES - PRIVATE
     private var appDidEnterBackgroundDate: Date?
     
-    init(dataManager: DataManager, settingsStore: SettingsStore ,timerProvider: Timer.Type) {
+    init(dataManager: DataManager, settingsStore: SettingsStore, payManager: PayManager ,timerProvider: Timer.Type) {
         self.dataManager = dataManager
         self.settingsStore = settingsStore
         self.timerProvider = timerProvider
+        self.payManager = payManager
         super.init()
         countSeconds = settingsStore.workTimeInSeconds
         updateTimerStringValue()
@@ -109,9 +111,8 @@ extension HomeViewModel {
     }
     
 }
-    
 
-    //MARK: TIMER START & STOP FUNCTIONS
+//MARK: TIMER START & STOP FUNCTIONS
 extension HomeViewModel {
 
     func startTimer()  {
@@ -144,7 +145,7 @@ extension HomeViewModel {
     }
 }
    
-    //MARK: TIMER UPDATE FUNCTIONS
+//MARK: TIMER UPDATE FUNCTIONS
 extension HomeViewModel {
     
     /**
@@ -226,11 +227,7 @@ extension HomeViewModel {
         let workTimeInSeconds = settingsStore.workTimeInSeconds - countSeconds
         let overTimeInSeconds = countOvertimeSeconds
         let calculatedNetPay: Double? = {
-            if settingsStore.isCalculatingNetPay {
-                let payService = PayManager(dataManager: dataManager, settingsStore: settingsStore)
-                return payService.calculateNetPay(gross: Double(settingsStore.grossPayPerMonth))
-            }
-            return nil
+            settingsStore.isCalculatingNetPay ? payManager.calculateNetPay(gross: Double(settingsStore.grossPayPerMonth)) : nil
         }()
         let entryToSave = Entry(startDate: startDate,
                                 finishDate: finishDate,

--- a/ClockIn/ViewModel/HomeViewModel.swift
+++ b/ClockIn/ViewModel/HomeViewModel.swift
@@ -225,9 +225,20 @@ extension HomeViewModel {
         
         let workTimeInSeconds = settingsStore.workTimeInSeconds - countSeconds
         let overTimeInSeconds = countOvertimeSeconds
-        
-        let entryToSave = Entry(startDate: startDate, finishDate: finishDate, workTimeInSec: workTimeInSeconds, overTimeInSec: overTimeInSeconds)
-        
+        let calculatedNetPay: Double? = {
+            if settingsStore.isCalculatingNetPay {
+                let payService = PayManager(dataManager: dataManager, settingsStore: settingsStore)
+                return payService.calculateNetPay(gross: Double(settingsStore.grossPayPerMonth))
+            }
+            return nil
+        }()
+        let entryToSave = Entry(startDate: startDate,
+                                finishDate: finishDate,
+                                workTimeInSec: workTimeInSeconds,
+                                overTimeInSec: overTimeInSeconds,
+                                maximumOvertimeAllowedInSeconds: settingsStore.maximumOvertimeAllowedInSeconds,
+                                standardWorktimeAllowedInSeconds: settingsStore.workTimeInSeconds,
+                                grossPayPerMonth: settingsStore.grossPayPerMonth, calculatedNetPay: calculatedNetPay)
         dataManager.updateAndSave(entry: entryToSave)
     }
 }

--- a/ClockIn/ViewModel/StatisticsViewModel.swift
+++ b/ClockIn/ViewModel/StatisticsViewModel.swift
@@ -115,7 +115,11 @@ class StatisticsViewModel: ObservableObject {
                 startDate: date,
                 finishDate: date,
                 workTimeInSec: 0,
-                overTimeInSec: 0
+                overTimeInSec: 0,
+                maximumOvertimeAllowedInSeconds: 5*3600,
+                standardWorktimeInSeconds: 8*3600,
+                grossPayPerMonth: 10000,
+                calculatedNetPay: nil
             )
             placeholders.append(placeholderEntry)
         }

--- a/ClockIn/WorkHistory.xcdatamodeld/WorkHistory.xcdatamodel/contents
+++ b/ClockIn/WorkHistory.xcdatamodeld/WorkHistory.xcdatamodel/contents
@@ -5,7 +5,7 @@
         <attribute name="finishDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="grossPayPerMonth" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="maximumOvertimeAllowedInSecond" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="maximumOvertimeAllowedInSeconds" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="overTime" attributeType="Integer 64" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="standardWorktimeInSeconds" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="startDate" attributeType="Date" usesScalarValueType="NO"/>

--- a/ClockIn/WorkHistory.xcdatamodeld/WorkHistory.xcdatamodel/contents
+++ b/ClockIn/WorkHistory.xcdatamodeld/WorkHistory.xcdatamodel/contents
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22225" systemVersion="23A344" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="EntryMO" representedClassName="EntryMO" syncable="YES">
-        <attribute name="calculatedNetPay" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="calculatedNetPay" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="finishDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="grossPayPerMonth" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>

--- a/ClockIn/WorkHistory.xcdatamodeld/WorkHistory.xcdatamodel/contents
+++ b/ClockIn/WorkHistory.xcdatamodeld/WorkHistory.xcdatamodel/contents
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22A400" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22225" systemVersion="23A344" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="EntryMO" representedClassName="EntryMO" syncable="YES">
+        <attribute name="calculatedNetPay" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="finishDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="grossPayPerMonth" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="maximumOvertimeAllowedInSecond" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="overTime" attributeType="Integer 64" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="standardWorktimeInSeconds" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="startDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="workTime" attributeType="Integer 64" defaultValueString="0.0" usesScalarValueType="YES"/>
     </entity>

--- a/ClockInTests/ChartPeriodServiceTests.swift
+++ b/ClockInTests/ChartPeriodServiceTests.swift
@@ -134,9 +134,9 @@ extension ChartPeriodServiceTests {
     func test_RetardingPeriodForWeek() throws {
         // Given
         guard let inputStartDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 20)),
-              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 26)),
+              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 27)),
               let expectedStartDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 13)),
-              let expectedFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 19)) else {
+              let expectedFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 20)) else {
                 XCTFail("Failed to generate input and predicted output dates")
                 return
             }
@@ -154,9 +154,9 @@ extension ChartPeriodServiceTests {
     func test_RetardingPeriodForMonth() throws {
         // Given
         guard let inputStartDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 1)),
-              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 30)),
+              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 12, day: 1)),
               let expectedStartDate = Calendar.current.date(from: DateComponents(year: 2023, month: 10, day: 1)),
-              let expectedFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 10, day: 31)) else {
+              let expectedFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 1)) else {
                 XCTFail("Failed to generate input and predicted output dates")
                 return
             }
@@ -174,9 +174,9 @@ extension ChartPeriodServiceTests {
     func test_RetardingPeriodForYear() throws {
         // Given
         guard let inputStartDate = Calendar.current.date(from: DateComponents(year: 2023, month: 1, day: 1)),
-              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 12, day: 31)),
+              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2024, month: 1, day: 1)),
               let expectedStartDate = Calendar.current.date(from: DateComponents(year: 2022, month: 1, day: 1)),
-              let expectedFinishDate = Calendar.current.date(from: DateComponents(year: 2022, month: 12, day: 31)) else {
+              let expectedFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 1, day: 1)) else {
                 XCTFail("Failed to generate input and predicted output dates")
                 return
             }

--- a/ClockInTests/ChartPeriodServiceTests.swift
+++ b/ClockInTests/ChartPeriodServiceTests.swift
@@ -22,6 +22,10 @@ final class ChartPeriodServiceTests: XCTestCase {
 
 //MARK: TEST FOR GENERATING PERIOD
 extension ChartPeriodServiceTests {
+    //NOTE ON DATE GENERATION IN TESTS
+    /*
+     Period service returns start of the day dates - hence, the finish of the period is a start of the next day to encompass whole day before
+     */
     func test_generatePeriod_forMonth() throws {
         // Given
         let inputDate = {
@@ -33,7 +37,7 @@ extension ChartPeriodServiceTests {
             return Calendar.current.date(from: dateComponents)
         }()
         let finishDate = {
-            let dateComponents = DateComponents(year: 2023, month: 11, day: 30)
+            let dateComponents = DateComponents(year: 2023, month: 12, day: 1)
             return Calendar.current.date(from: dateComponents)
         }()
         guard let inputDate, let startDate, let finishDate else {
@@ -61,7 +65,7 @@ extension ChartPeriodServiceTests {
             return Calendar.current.date(from: dateComponents)
         }()
         let finishDate = {
-            let dateComponents = DateComponents(year: 2023, month: 11, day: 26)
+            let dateComponents = DateComponents(year: 2023, month: 11, day: 27)
             return Calendar.current.date(from: dateComponents)
         }()
         guard let inputDate, let startDate, let finishDate else {
@@ -89,7 +93,7 @@ extension ChartPeriodServiceTests {
             return Calendar.current.date(from: dateComponents)
         }()
         let finishDate = {
-            let dateComponents = DateComponents(year: 2023, month: 12, day: 31)
+            let dateComponents = DateComponents(year: 2024, month: 1, day: 1)
             return Calendar.current.date(from: dateComponents)
         }()
         guard let inputDate, let startDate, let finishDate else {

--- a/ClockInTests/ChartPeriodServiceTests.swift
+++ b/ClockInTests/ChartPeriodServiceTests.swift
@@ -211,9 +211,9 @@ extension ChartPeriodServiceTests {
     func test_advancingPeriodForWeek() throws {
         // Given
         guard let inputStartDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 13)),
-              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 19)),
+              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 20)),
               let expectedStartDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 20)),
-              let expectedFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 26)) else {
+              let expectedFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 27)) else {
                 XCTFail("Failed to generate input and predicted output dates")
                 return
             }
@@ -231,9 +231,9 @@ extension ChartPeriodServiceTests {
     func test_advancingPeriodForMonth() throws {
         // Given
         guard let inputStartDate = Calendar.current.date(from: DateComponents(year: 2023, month: 10, day: 1)),
-              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 10, day: 31)),
+              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 1)),
               let expectedStartDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 1)),
-              let expectedFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 30)) else {
+              let expectedFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 12, day: 1)) else {
                 XCTFail("Failed to generate input and predicted output dates")
                 return
             }
@@ -251,9 +251,9 @@ extension ChartPeriodServiceTests {
     func test_advancingPeriodForYear() throws {
         // Given
         guard let inputStartDate = Calendar.current.date(from: DateComponents(year: 2022, month: 1, day: 1)),
-              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2022, month: 12, day: 31)),
+              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 1, day: 1)),
               let expectedStartDate = Calendar.current.date(from: DateComponents(year: 2023, month: 1, day: 1)),
-              let expectedFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 12, day: 31)) else {
+              let expectedFinishDate = Calendar.current.date(from: DateComponents(year: 2024, month: 1, day: 1)) else {
                 XCTFail("Failed to generate input and predicted output dates")
                 return
             }

--- a/ClockInTests/HistoryViewModelTests.swift
+++ b/ClockInTests/HistoryViewModelTests.swift
@@ -44,11 +44,12 @@ final class HistoryViewModelTests: XCTestCase {
                     sizeOfChunk: nil)
         
         XCTAssertEqual(sut.groupedEntries.count, 12)
+        // something broke here? 
         for (i, monthArray) in sut.groupedEntries.enumerated() {
             let correctMonthNumber = i + 1
             for entry in monthArray {
                 let monthNumber = calendar.dateComponents([.month], from: entry.startDate).month
-                XCTAssertEqual(correctMonthNumber, correctMonthNumber, "Month number should be 1 more than array index")
+                XCTAssertEqual(monthNumber, correctMonthNumber, "Month number should be 1 more than array index")
             }
         }
     }
@@ -142,23 +143,33 @@ final class HistoryViewModelTests: XCTestCase {
         XCTAssertEqual(sut.groupedEntries.flatMap({ $0 }).count, chunkSize, "Number of entries should be equal to two times chunk size")
         
     }
+    // this is ok to fail for now
+    //TODO: REMOVE THE FUNCTIONS AND COVERT TO GET PROPERTIES IN ENTRY
     func testConvertOvertimeToFraction_for2hours30minutes() {
         let startDate = Calendar.current.date(byAdding: .hour, value: -7 , to: Date())!
         let finishDate = Calendar.current.date(byAdding: .hour, value: 2 , to: Date())!
-        let entry = Entry(startDate: startDate, finishDate: finishDate, workTimeInSec: 8 * 3600, overTimeInSec: Int(2.5 * 3600))
+        let entry = Entry(startDate: startDate, finishDate: finishDate, workTimeInSec: 8 * 3600, overTimeInSec: Int(2.5 * 3600),
+                          maximumOvertimeAllowedInSeconds: 5*3600,
+                          standardWorktimeInSeconds: 8*3600,
+                          grossPayPerMonth: 10000,
+                          calculatedNetPay: nil)
         
         let result = sut.convertOvertimeToFraction(entry: entry)
         
         XCTAssertTrue(result == 0.5, "Results should be 0.5")
     }
-    
+    //TODO: REMOVE THE FUNCTION AND CONVERT TO GET PROPERTY IN ENTRY
     func testConvertWorkTimeToFraction_for4hours() {
         let startDate = Calendar.current.date(byAdding: .hour, value: -7 , to: Date())!
         let finishDate = Calendar.current.date(byAdding: .hour, value: 2 , to: Date())!
         let entry = Entry(startDate: startDate,
                           finishDate: finishDate,
                           workTimeInSec: 4 * 3600,
-                          overTimeInSec: 0)
+                          overTimeInSec: 0,
+                          maximumOvertimeAllowedInSeconds: 5*3600,
+                          standardWorktimeInSeconds: 8*3600,
+                          grossPayPerMonth: 10000,
+                          calculatedNetPay: nil)
         
         let result = sut.convertWorkTimeToFraction(entry: entry)
         

--- a/ClockInTests/HistoryViewModelTests.swift
+++ b/ClockInTests/HistoryViewModelTests.swift
@@ -145,36 +145,4 @@ final class HistoryViewModelTests: XCTestCase {
         XCTAssertEqual(sut.groupedEntries.flatMap({ $0 }).count, chunkSize, "Number of entries should be equal to two times chunk size")
         
     }
-    // this is ok to fail for now
-    //TODO: REMOVE THE FUNCTIONS AND COVERT TO GET PROPERTIES IN ENTRY
-    func testConvertOvertimeToFraction_for2hours30minutes() {
-        let startDate = Calendar.current.date(byAdding: .hour, value: -7 , to: Date())!
-        let finishDate = Calendar.current.date(byAdding: .hour, value: 2 , to: Date())!
-        let entry = Entry(startDate: startDate, finishDate: finishDate, workTimeInSec: 8 * 3600, overTimeInSec: Int(2.5 * 3600),
-                          maximumOvertimeAllowedInSeconds: 5*3600,
-                          standardWorktimeInSeconds: 8*3600,
-                          grossPayPerMonth: 10000,
-                          calculatedNetPay: nil)
-        
-        let result = sut.convertOvertimeToFraction(entry: entry)
-        
-        XCTAssertTrue(result == 0.5, "Results should be 0.5")
-    }
-    //TODO: REMOVE THE FUNCTION AND CONVERT TO GET PROPERTY IN ENTRY
-    func testConvertWorkTimeToFraction_for4hours() {
-        let startDate = Calendar.current.date(byAdding: .hour, value: -7 , to: Date())!
-        let finishDate = Calendar.current.date(byAdding: .hour, value: 2 , to: Date())!
-        let entry = Entry(startDate: startDate,
-                          finishDate: finishDate,
-                          workTimeInSec: 4 * 3600,
-                          overTimeInSec: 0,
-                          maximumOvertimeAllowedInSeconds: 5*3600,
-                          standardWorktimeInSeconds: 8*3600,
-                          grossPayPerMonth: 10000,
-                          calculatedNetPay: nil)
-        
-        let result = sut.convertWorkTimeToFraction(entry: entry)
-        
-        XCTAssertTrue(result == 0.5, "Results should be 0.5")
-    }
 }

--- a/ClockInTests/HistoryViewModelTests.swift
+++ b/ClockInTests/HistoryViewModelTests.swift
@@ -25,6 +25,7 @@ final class HistoryViewModelTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         sut = nil
+        container.dataManager.deleteAll()
         container = nil
     }
     
@@ -116,6 +117,7 @@ final class HistoryViewModelTests: XCTestCase {
         XCTAssertEqual(sut.groupedEntries.flatMap({ $0 }).count, 5, "There should be 5 entries")
         
     }
+    
     func test_resetFilters() {
         sut = nil
         let calendar = Calendar.current

--- a/ClockInTests/HistoryViewModelTests.swift
+++ b/ClockInTests/HistoryViewModelTests.swift
@@ -44,9 +44,9 @@ final class HistoryViewModelTests: XCTestCase {
                     sizeOfChunk: nil)
         
         XCTAssertEqual(sut.groupedEntries.count, 12)
-        // something broke here? 
+        
         for (i, monthArray) in sut.groupedEntries.enumerated() {
-            let correctMonthNumber = i + 1
+            let correctMonthNumber = 12 - i
             for entry in monthArray {
                 let monthNumber = calendar.dateComponents([.month], from: entry.startDate).month
                 XCTAssertEqual(monthNumber, correctMonthNumber, "Month number should be 1 more than array index")

--- a/ClockInTests/HomeViewModelTests.swift
+++ b/ClockInTests/HomeViewModelTests.swift
@@ -19,6 +19,7 @@ final class HomeViewModelModelTests: XCTestCase {
         self.settingsStore = SettingsStore()
         sut = .init(HomeViewModel(dataManager: DataManager.testing,
                                   settingsStore: settingsStore,
+                                  payManager: PayManager(dataManager: DataManager.testing, settingsStore: settingsStore),
                                   timerProvider: MockTimer.self)
         )
     }

--- a/ClockInTests/PayManagerTests.swift
+++ b/ClockInTests/PayManagerTests.swift
@@ -12,10 +12,12 @@ import CoreData
 final class PayManagerTests: XCTestCase {
 
     var sut: PayManager!
-    
+    var container: Container!
     override func setUp() {
         super.setUp()
-        sut = .init(dataManager: DataManager.testing, settingsStore: SettingsStore())
+        container = Container()
+        sut = .init(dataManager: container.dataManager,
+                    settingsStore: container.settingsStore)
     }
 
     override func tearDown() {
@@ -39,10 +41,8 @@ final class PayManagerTests: XCTestCase {
         let numberOfDays = sut.getNumberOfWorkingDays(inMonthOfDate: date)
         
         XCTAssert(numberOfDays == 20, "Number of working days should be 20" )
-        
-        
-        
     }
+    
     func testCalculateGrossPay_whenNoDateIsGiven() {
         //Add entries to memory
         let components = Calendar.current.dateComponents([.month, .year], from: Date())
@@ -61,7 +61,7 @@ final class PayManagerTests: XCTestCase {
                 overTimeInSec: 0,
                 maximumOvertimeAllowedInSeconds: 5*3600,
                 standardWorktimeInSeconds: 8*3600,
-                grossPayPerMonth: 10000,
+                grossPayPerMonth: container.settingsStore.grossPayPerMonth,
                 calculatedNetPay: nil)
             DataManager.testing.updateAndSave(entry: entry)
         }

--- a/ClockInTests/PayManagerTests.swift
+++ b/ClockInTests/PayManagerTests.swift
@@ -20,27 +20,27 @@ final class PayManagerTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
+        DataManager.testing.deleteAll()
         sut = nil
     }
     
     func testGetNumberOfWorkingDays() {
         
-        let formatter = Date.FormatStyle()
-            .year(.defaultDigits)
-            .month(.wide)
-            .day(.defaultDigits)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM d, yyyy"
         let dateString = "April 16, 2023"
         
-        do {
-            let date = try formatter.parse(dateString)
-            
-            let numberOfDays = sut.getNumberOfWorkingDays(inMonthOfDate: date)
-            
-            XCTAssert(numberOfDays == 20, "Number of working days should be 20" )
-            
-        } catch {
-            XCTFail(error.localizedDescription)
+        
+        guard let date = formatter.date(from: dateString) else {
+            XCTFail("Failed to build date from given string")
+            return
         }
+        
+        let numberOfDays = sut.getNumberOfWorkingDays(inMonthOfDate: date)
+        
+        XCTAssert(numberOfDays == 20, "Number of working days should be 20" )
+        
+        
         
     }
     func testCalculateGrossPay_whenNoDateIsGiven() {

--- a/ClockInTests/PayManagerTests.swift
+++ b/ClockInTests/PayManagerTests.swift
@@ -58,7 +58,11 @@ final class PayManagerTests: XCTestCase {
                 startDate:  Calendar.current.date(byAdding: .hour, value: 8, to: date)!,
                 finishDate: Calendar.current.date(byAdding: .hour, value: 16, to: date)!,
                 workTimeInSec: 8 * 3600,
-                overTimeInSec: 0)
+                overTimeInSec: 0,
+                maximumOvertimeAllowedInSeconds: 5*3600,
+                standardWorktimeInSeconds: 8*3600,
+                grossPayPerMonth: 10000,
+                calculatedNetPay: nil)
             DataManager.testing.updateAndSave(entry: entry)
         }
         

--- a/ClockInTests/StatisticsViewModelTests.swift
+++ b/ClockInTests/StatisticsViewModelTests.swift
@@ -43,9 +43,9 @@ final class StatisticsViewModelTests: XCTestCase {
             let startOfTheMonth = Calendar.current.date(from: components)!
             return Calendar.current.range(of: .day, in: .month, for: startOfTheMonth)!.count
         }()
-        
+        sut.chartTimeRange = .month
         let result = sut.entriesForChart
-        XCTAssert(result.count == correctValue, "There should be 7 objects in the array")
+        XCTAssert(result.count == correctValue, "There should be objects in the array")
     }
     
     func test_createPlaceholderEntries() {

--- a/ClockInTests/StatisticsViewModelTests.swift
+++ b/ClockInTests/StatisticsViewModelTests.swift
@@ -50,13 +50,14 @@ final class StatisticsViewModelTests: XCTestCase {
     
     func test_createPlaceholderEntries() {
         guard let inputStartDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 13)),
-              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 19)) else {
+              let inputFinishDate = Calendar.current.date(from: DateComponents(year: 2023, month: 11, day: 20)),
+              let expectedLastEntryDate = Calendar.current.date(byAdding: .day, value: -1, to: inputFinishDate) else {
                 XCTFail("Failed to generate input and predicted output dates")
                 return
             }
         let inputPeriod = (inputStartDate, inputFinishDate)
         let result = sut.createPlaceholderEntries(for: inputPeriod)
         XCTAssertTrue(result[0].startDate == inputStartDate, "Results should start with entry with input start date")
-        XCTAssertTrue(result.last?.startDate == inputFinishDate, "Results should end with entry with input finish date")
+        XCTAssertTrue(result.last?.startDate == expectedLastEntryDate, "Results should end with entry with input finish date")
     }
 }

--- a/ClockInTests/StatisticsViewModelTests.swift
+++ b/ClockInTests/StatisticsViewModelTests.swift
@@ -32,7 +32,12 @@ final class StatisticsViewModelTests: XCTestCase {
             startDate: Calendar.current.date(byAdding: .hour, value: -8, to: Date())!,
             finishDate: Date(),
             workTimeInSec: 8 * 3600,
-            overTimeInSec: 0))
+            overTimeInSec: 0,
+            maximumOvertimeAllowedInSeconds: 5*3600,
+            standardWorktimeInSeconds: 8*3600,
+            grossPayPerMonth: 10000,
+            calculatedNetPay: nil)
+        )
         let correctValue: Int = {
             let components = Calendar.current.dateComponents([.month, .year], from: Date())
             let startOfTheMonth = Calendar.current.date(from: components)!


### PR DESCRIPTION
Adds enhancement requested in GH issue 16. 

Added:
- additional properties in EntryMO and Entry 
- saving additional properties for setting store on data creation 
Fixes:
- various failing unit test due to changes in data manager

Additionally small refactoring was done to affected view models