### PR TITLE
Add additional entry data editing to editing view

### DIFF
--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		D6C458C529D35EAA0069D89B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C429D35EAA0069D89B /* SettingsView.swift */; };
 		D6C458C729D36C050069D89B /* RingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C629D36C050069D89B /* RingView.swift */; };
 		D6CB2A7C2B05629200F3030C /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CB2A7B2B05629200F3030C /* View+Extension.swift */; };
+		D6CBB8662B3443360074CE8B /* EditSheetViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CBB8652B3443360074CE8B /* EditSheetViewModelTests.swift */; };
 		D6D02FAE29EF0B13006CD0B2 /* EditSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D02FAD29EF0B13006CD0B2 /* EditSheetView.swift */; };
 		D6D02FB029EF0B7F006CD0B2 /* EditShetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D02FAF29EF0B7F006CD0B2 /* EditShetViewModel.swift */; };
 		D6D906AE2AA0BEDE004E09C9 /* ScreenIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */; };
@@ -161,6 +162,7 @@
 		D6C458C429D35EAA0069D89B /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		D6C458C629D36C050069D89B /* RingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingView.swift; sourceTree = "<group>"; };
 		D6CB2A7B2B05629200F3030C /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
+		D6CBB8652B3443360074CE8B /* EditSheetViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSheetViewModelTests.swift; sourceTree = "<group>"; };
 		D6D02FAD29EF0B13006CD0B2 /* EditSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSheetView.swift; sourceTree = "<group>"; };
 		D6D02FAF29EF0B7F006CD0B2 /* EditShetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditShetViewModel.swift; sourceTree = "<group>"; };
 		D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenIdentifier.swift; sourceTree = "<group>"; };
@@ -309,6 +311,7 @@
 				D61945EF29E735D80046DE1F /* MockTimer.swift */,
 				D6842EC529EC6FDE00731E84 /* PayManagerTests.swift */,
 				D6C458A429D229230069D89B /* ClockInTests.swift */,
+				D6CBB8652B3443360074CE8B /* EditSheetViewModelTests.swift */,
 			);
 			path = ClockInTests;
 			sourceTree = "<group>";
@@ -585,6 +588,7 @@
 				D60480D82B122CDA00D6D70D /* ChartPeriodServiceTests.swift in Sources */,
 				D61945F029E735D80046DE1F /* MockTimer.swift in Sources */,
 				D6C458A529D229230069D89B /* ClockInTests.swift in Sources */,
+				D6CBB8662B3443360074CE8B /* EditSheetViewModelTests.swift in Sources */,
 				D6799EFC29E1BC0F0080E32A /* HistoryViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -808,7 +812,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 73N45UT488;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = tomaszkubiak.ClockInTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -828,7 +832,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 73N45UT488;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = tomaszkubiak.ClockInTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		D64574B429D9F16900207168 /* EntryMO+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574B229D9F16900207168 /* EntryMO+CoreDataProperties.swift */; };
 		D64574B629D9F37400207168 /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574B529D9F37400207168 /* Entry.swift */; };
 		D64766C52AFEBD9D0013AC9A /* ChartLegendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64766C42AFEBD9D0013AC9A /* ChartLegendView.swift */; };
+		D653FEEC2B320E1600ECFCF2 /* TimeIntervalPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D653FEEB2B320E1600ECFCF2 /* TimeIntervalPicker.swift */; };
 		D65A976B29F2E6B800462D8C /* StatisticsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65A976A29F2E6B800462D8C /* StatisticsViewModelTests.swift */; };
 		D65A976D29F323A900462D8C /* K.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65A976C29F323A900462D8C /* K.swift */; };
 		D65A976F29F3BBDD00462D8C /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65A976E29F3BBDD00462D8C /* OnboardingView.swift */; };
@@ -120,6 +121,7 @@
 		D64574B229D9F16900207168 /* EntryMO+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EntryMO+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		D64574B529D9F37400207168 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		D64766C42AFEBD9D0013AC9A /* ChartLegendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartLegendView.swift; sourceTree = "<group>"; };
+		D653FEEB2B320E1600ECFCF2 /* TimeIntervalPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIntervalPicker.swift; sourceTree = "<group>"; };
 		D65A976A29F2E6B800462D8C /* StatisticsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewModelTests.swift; sourceTree = "<group>"; };
 		D65A976C29F323A900462D8C /* K.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K.swift; sourceTree = "<group>"; };
 		D65A976E29F3BBDD00462D8C /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -341,6 +343,7 @@
 				D64766C42AFEBD9D0013AC9A /* ChartLegendView.swift */,
 				D6FA94FC2B013F060034B16A /* ChartLegendItemView.swift */,
 				D65A976E29F3BBDD00462D8C /* OnboardingView.swift */,
+				D653FEEB2B320E1600ECFCF2 /* TimeIntervalPicker.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -535,6 +538,7 @@
 				D6EA695C2AF8452A00D8F6C3 /* TextFactory.swift in Sources */,
 				D64574B329D9F16900207168 /* EntryMO+CoreDataClass.swift in Sources */,
 				D64574B429D9F16900207168 /* EntryMO+CoreDataProperties.swift in Sources */,
+				D653FEEC2B320E1600ECFCF2 /* TimeIntervalPicker.swift in Sources */,
 				D6D906AE2AA0BEDE004E09C9 /* ScreenIdentifier.swift in Sources */,
 				D61F11342AB3A6FF00902D6D /* ColorScheme+Extension.swift in Sources */,
 				D684A38A2AF6F54B00511E0D /* ButtonFactory.swift in Sources */,
@@ -673,7 +677,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -727,7 +731,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		D6C458C729D36C050069D89B /* RingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C458C629D36C050069D89B /* RingView.swift */; };
 		D6CB2A7C2B05629200F3030C /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CB2A7B2B05629200F3030C /* View+Extension.swift */; };
 		D6CBB8662B3443360074CE8B /* EditSheetViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CBB8652B3443360074CE8B /* EditSheetViewModelTests.swift */; };
+		D6CBB8682B34ACF20074CE8B /* Calendar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CBB8672B34ACF20074CE8B /* Calendar+Extension.swift */; };
 		D6D02FAE29EF0B13006CD0B2 /* EditSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D02FAD29EF0B13006CD0B2 /* EditSheetView.swift */; };
 		D6D02FB029EF0B7F006CD0B2 /* EditShetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D02FAF29EF0B7F006CD0B2 /* EditShetViewModel.swift */; };
 		D6D906AE2AA0BEDE004E09C9 /* ScreenIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */; };
@@ -163,6 +164,7 @@
 		D6C458C629D36C050069D89B /* RingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingView.swift; sourceTree = "<group>"; };
 		D6CB2A7B2B05629200F3030C /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		D6CBB8652B3443360074CE8B /* EditSheetViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSheetViewModelTests.swift; sourceTree = "<group>"; };
+		D6CBB8672B34ACF20074CE8B /* Calendar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+Extension.swift"; sourceTree = "<group>"; };
 		D6D02FAD29EF0B13006CD0B2 /* EditSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSheetView.swift; sourceTree = "<group>"; };
 		D6D02FAF29EF0B7F006CD0B2 /* EditShetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditShetViewModel.swift; sourceTree = "<group>"; };
 		D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenIdentifier.swift; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 				D6CB2A7B2B05629200F3030C /* View+Extension.swift */,
 				D666ADCB2AC05A0500B74663 /* CaseIterable+Extension.swift */,
 				D6BC457D2AFAE0640030820C /* ColorTheme.swift */,
+				D6CBB8672B34ACF20074CE8B /* Calendar+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -529,6 +532,7 @@
 				D64766C52AFEBD9D0013AC9A /* ChartLegendView.swift in Sources */,
 				D64574B629D9F37400207168 /* Entry.swift in Sources */,
 				D6C458C729D36C050069D89B /* RingView.swift in Sources */,
+				D6CBB8682B34ACF20074CE8B /* Calendar+Extension.swift in Sources */,
 				D6EA695E2AF8498D00D8F6C3 /* OnboardingOvertimeView.swift in Sources */,
 				D6E6B8772AF992F90073D911 /* OnboardingFinishView.swift in Sources */,
 				D6CB2A7C2B05629200F3030C /* View+Extension.swift in Sources */,

--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		D6CB2A7C2B05629200F3030C /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CB2A7B2B05629200F3030C /* View+Extension.swift */; };
 		D6CBB8662B3443360074CE8B /* EditSheetViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CBB8652B3443360074CE8B /* EditSheetViewModelTests.swift */; };
 		D6CBB8682B34ACF20074CE8B /* Calendar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CBB8672B34ACF20074CE8B /* Calendar+Extension.swift */; };
+		D6CBB86A2B34C7150074CE8B /* FormatterFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6CBB8692B34C7150074CE8B /* FormatterFactory.swift */; };
 		D6D02FAE29EF0B13006CD0B2 /* EditSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D02FAD29EF0B13006CD0B2 /* EditSheetView.swift */; };
 		D6D02FB029EF0B7F006CD0B2 /* EditShetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D02FAF29EF0B7F006CD0B2 /* EditShetViewModel.swift */; };
 		D6D906AE2AA0BEDE004E09C9 /* ScreenIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */; };
@@ -165,6 +166,7 @@
 		D6CB2A7B2B05629200F3030C /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		D6CBB8652B3443360074CE8B /* EditSheetViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSheetViewModelTests.swift; sourceTree = "<group>"; };
 		D6CBB8672B34ACF20074CE8B /* Calendar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+Extension.swift"; sourceTree = "<group>"; };
+		D6CBB8692B34C7150074CE8B /* FormatterFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatterFactory.swift; sourceTree = "<group>"; };
 		D6D02FAD29EF0B13006CD0B2 /* EditSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditSheetView.swift; sourceTree = "<group>"; };
 		D6D02FAF29EF0B7F006CD0B2 /* EditShetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditShetViewModel.swift; sourceTree = "<group>"; };
 		D6D906AD2AA0BEDE004E09C9 /* ScreenIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenIdentifier.swift; sourceTree = "<group>"; };
@@ -375,6 +377,7 @@
 				D684A3892AF6F54B00511E0D /* ButtonFactory.swift */,
 				D6EA695B2AF8452A00D8F6C3 /* TextFactory.swift */,
 				D6FA94FE2B0145FE0034B16A /* ChartFactory.swift */,
+				D6CBB8692B34C7150074CE8B /* FormatterFactory.swift */,
 			);
 			path = Factory;
 			sourceTree = "<group>";
@@ -563,6 +566,7 @@
 				D67332E62AADB8B1005FFE7F /* LaunchArgument.swift in Sources */,
 				D68384F929DB25DD00228491 /* SettingViewModel.swift in Sources */,
 				D6C458C329D2DE2D0069D89B /* HomeView.swift in Sources */,
+				D6CBB86A2B34C7150074CE8B /* FormatterFactory.swift in Sources */,
 				D61F11312AB38F8700902D6D /* SettingsStore.swift in Sources */,
 				D6842EC029EC178000731E84 /* StatisticsView.swift in Sources */,
 				D66750EC29D71C8300757F17 /* HistoryRow.swift in Sources */,

--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -139,7 +139,7 @@
 		D684A3892AF6F54B00511E0D /* ButtonFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonFactory.swift; sourceTree = "<group>"; };
 		D68732012B2243C9008CB0D4 /* PaginationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationState.swift; sourceTree = "<group>"; };
 		D6AB736F29F562E600D5DE82 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
-		D6B2BDF12B27810700CB4FA7 /* DateFilterSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DateFilterSheetView.swift; path = ClockIn/View/DateFilterSheetView.swift; sourceTree = "<group>"; };
+		D6B2BDF12B27810700CB4FA7 /* DateFilterSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFilterSheetView.swift; sourceTree = "<group>"; };
 		D6B2BDF32B27C22400CB4FA7 /* EmptyPlaceholderModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyPlaceholderModifier.swift; sourceTree = "<group>"; };
 		D6B3B2652ABA237800101A1F /* SettingsViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewUITests.swift; sourceTree = "<group>"; };
 		D6B7D1C72B0EB41A00E6F7A8 /* ContentViewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewScreen.swift; sourceTree = "<group>"; };
@@ -252,7 +252,6 @@
 		D6C4588729D229200069D89B = {
 			isa = PBXGroup;
 			children = (
-				D6B2BDF12B27810700CB4FA7 /* DateFilterSheetView.swift */,
 				D6C4589229D229210069D89B /* ClockIn */,
 				D6C458A329D229230069D89B /* ClockInTests */,
 				D6C458AD29D229230069D89B /* ClockInUITests */,
@@ -332,6 +331,7 @@
 				D684A3862AF6F3C700511E0D /* OboardingViews */,
 				D6C4589529D229210069D89B /* ContentView.swift */,
 				D6C458C229D2DE2D0069D89B /* HomeView.swift */,
+				D6B2BDF12B27810700CB4FA7 /* DateFilterSheetView.swift */,
 				D66750E929D713C900757F17 /* HistoryView.swift */,
 				D66750EB29D71C8300757F17 /* HistoryRow.swift */,
 				D6C458C629D36C050069D89B /* RingView.swift */,

--- a/ClockIn/Extensions/Calendar+Extension.swift
+++ b/ClockIn/Extensions/Calendar+Extension.swift
@@ -1,0 +1,51 @@
+//
+//  Calendar+Extension.swift
+//  ClockIn
+//
+//  Created by Tomasz Kubiak on 21/12/2023.
+//
+
+import Foundation
+
+extension Calendar.Component {
+    
+    /// A writable key path to date component property of Int? type, corresponsing with given calendar component
+    /// If the keypath contains propety of diffferent type (like Bool), the var will return nil
+    /// Not implemented calendar components will return nil as well.
+    var dateComponentKeyPath: WritableKeyPath<DateComponents, Int?>? {
+        switch self {
+        case .era:
+            return \.era
+        case .year:
+            return \.year
+        case .month:
+            return \.month
+        case .day:
+            return \.day
+        case .hour:
+            return \.hour
+        case .minute:
+            return \.minute
+        case .second:
+            return \.second
+        case .weekday:
+            return \.weekday
+        case .weekdayOrdinal:
+            return \.weekdayOrdinal
+        case .quarter:
+            return \.quarter
+        case .weekOfMonth:
+            return \.weekOfMonth
+        case .weekOfYear:
+            return \.weekOfYear
+        case .yearForWeekOfYear:
+            return \.yearForWeekOfYear
+        case .nanosecond:
+            return \.nanosecond
+        case .calendar, .timeZone, .isLeapMonth:
+            return nil
+        @unknown default:
+            return nil
+        }
+    }
+}

--- a/ClockIn/Factory/FormatterFactory.swift
+++ b/ClockIn/Factory/FormatterFactory.swift
@@ -1,0 +1,19 @@
+//
+//  FormatterFactory.swift
+//  ClockIn
+//
+//  Created by Tomasz Kubiak on 21/12/2023.
+//
+
+import Foundation
+
+struct FormatterFactory {
+    static func makeDateComponentFormatter() -> DateComponentsFormatter {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .positional
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.zeroFormattingBehavior = [.pad]
+        return formatter
+    }
+    
+}

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -19,8 +19,8 @@ struct EditSheetView: View {
     let titleText: String = "Edit entry"
     let timeIndicatorText: String = "work time"
     let overrideSettingsHeaderText: String = "Override settings"
-    let startDateText: String = "Start date"
-    let finishDateText: String = "Finish date"
+    let startDateText: String = "Start"
+    let finishDateText: String = "Finish"
     let saveButtonText: String = "save"
     let cancelButtonText: String = "cancel"
     var body: some View {
@@ -41,7 +41,7 @@ struct EditSheetView: View {
                         overtimeLabel
                     }
                     Divider()
-                    dateControls
+                    dateControls()
                     Divider()
                     overrideSettingsHeader
                         .padding(.top)
@@ -149,7 +149,16 @@ struct EditSheetView: View {
         } // END OF HSTACK
     }
     
-    var dateControls: some View {
+    @ViewBuilder
+    func dateControls() -> some View {
+        if !viewModel.shouldDisplayFullDates {
+            sameDayDateControls
+        } else {
+            diffDayDateControls
+        }
+    }
+    
+    var diffDayDateControls: some View {
         Group {
             DatePicker(startDateText, selection: $viewModel.startDate)
                 .accessibilityIdentifier(Identifier.DatePicker.startDate.rawValue)
@@ -158,6 +167,36 @@ struct EditSheetView: View {
         }
     }
     
+    var sameDayDateControls: some View {
+        Group {
+            DatePicker(selection: $viewModel.startDate,
+                       displayedComponents: .date) {
+                Image(systemName: "calendar")
+            }
+                       .fixedSize()
+            HStack {
+                VStack(alignment: .leading) {
+                    Text(startDateText)
+                        .font(.caption)
+                    
+                    DatePicker(selection: $viewModel.startDate,
+                               displayedComponents: .hourAndMinute) {
+                        Image(systemName: "clock")
+                    }
+                               .fixedSize()
+                }
+                VStack(alignment: .leading) {
+                    Text(finishDateText)
+                        .font(.caption)
+                    DatePicker(selection: $viewModel.finishDate,
+                               displayedComponents: .hourAndMinute) {
+                        Image(systemName: "clock")
+                    }
+                               .fixedSize()
+                }
+            }
+        }
+    }
     var timeIndicator: some View {
         ZStack {
             RingView(startPoint: .constant(0),endPoint: $viewModel.workTimeFraction, ringColor: .blue, ringWidth: 5,displayPointer: false)

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -113,7 +113,8 @@ extension EditSheetView {
             GridRow {
                 Text(grossPayPerMonthText)
                 TextField("PLN",
-                          text: $viewModel.grossPayPerMonth)
+                          value: $viewModel.grossPayPerMonth,
+                          format: .currency(code: "PLN"))
                 .textFieldStyle(.roundedBorder)
             }
             

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-//TODO: ADD CHECKING FOR BEFORE AND AFTER DATE IN THE PICKERS TO NOT LET CHOOSE A NEGATIVE INTERVAL <- THIS WILL CRASH THE APP
 struct EditSheetView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) var dismiss
@@ -302,6 +301,7 @@ struct EditSheetView_Previews: PreviewProvider {
                 EditSheetView(viewModel:
                                 EditSheetViewModel(dataManager: container.dataManager,
                                                    settingsStore: container.settingsStore,
+                                                   payService: container.payManager,
                                                    entry: entry)
                 )
             }

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -197,6 +197,7 @@ struct EditSheetView: View {
             }
         }
     }
+    
     var timeIndicator: some View {
         ZStack {
             RingView(startPoint: .constant(0),endPoint: $viewModel.workTimeFraction, ringColor: .blue, ringWidth: 5,displayPointer: false)
@@ -205,7 +206,7 @@ struct EditSheetView: View {
             VStack {
                 Text(timeIndicatorText.uppercased())
                     .font(.caption)
-                Text("04:20")
+                Text(viewModel.totalTimeWorked)
                     .font(.largeTitle)
             }
         }  // END OF ZSTACK
@@ -229,11 +230,13 @@ struct EditSheetView_Previews: PreviewProvider {
         private let entry: Entry = {
             let startOfDay = Calendar.current.startOfDay(for: Date())
             let startDate = Calendar.current.date(byAdding: .hour, value: 6, to: startOfDay)!
-            let finishDate = Calendar.current.date(byAdding: .hour, value: 9, to: startDate)!
-            return Entry(startDate: startDate, 
+            let finishDate = Calendar.current.date(byAdding: .minute,
+                                                   value: 9 * 60 + 30,
+                                                   to: startDate)!
+            return Entry(startDate: startDate,
                          finishDate: finishDate,
                          workTimeInSec: 8*3600,
-                         overTimeInSec: 3600,
+                         overTimeInSec: 3600 + 1800,
                          maximumOvertimeAllowedInSeconds: 5*3600,
                          standardWorktimeInSeconds: 8*3600,
                          grossPayPerMonth: 10000,

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -36,9 +36,7 @@ struct EditSheetView: View {
         return formatter
     }()
     
-    private func generateTimeIntervalLabel(value: TimeInterval) -> String {
-        return dateComponentFormatter.string(from: value) ?? "00:00"
-    }
+    
 } // END OF STRUCT
 
 //MARK: BODY
@@ -77,15 +75,19 @@ extension EditSheetView {
     } // END OF BODY
 }
 
-// MARK: VIEW BUILDERS
+// MARK: VIEW BUILDERS & FUNCTIONS
 extension EditSheetView {
     @ViewBuilder
-    func dateControls() -> some View {
+    private func dateControls() -> some View {
         if !viewModel.shouldDisplayFullDates {
             sameDayDateControls
         } else {
             diffDayDateControls
         }
+    }
+    
+    private func generateTimeIntervalLabel(value: TimeInterval) -> String {
+        return dateComponentFormatter.string(from: value) ?? "00:00"
     }
 }
 
@@ -147,6 +149,7 @@ extension EditSheetView {
                         .font(.caption)
                     
                     DatePicker(selection: $viewModel.startDate,
+                               in: PartialRangeThrough(viewModel.finishDate),
                                displayedComponents: .hourAndMinute) {
                         Image(systemName: "clock")
                     }
@@ -156,6 +159,7 @@ extension EditSheetView {
                     Text(finishDateText)
                         .font(.caption)
                     DatePicker(selection: $viewModel.finishDate,
+                               in: PartialRangeFrom(viewModel.startDate),
                                displayedComponents: .hourAndMinute) {
                         Image(systemName: "clock")
                     }
@@ -305,4 +309,4 @@ struct EditSheetView_Previews: PreviewProvider {
     static var previews: some View {
         ContainerView()
     } // END OF PREVIEWS
-} // END OF STRUCT
+} // END OF PREVIEW

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -16,6 +16,13 @@ struct EditSheetView: View {
     @State private var isShowingOverrideControls: Bool = false
     let regularTimeText: String = "Regular time"
     let overtimeText: String = "Overtime"
+    let titleText: String = "Edit entry"
+    let timeIndicatorText: String = "work time"
+    let overrideSettingsHeaderText: String = "Override settings"
+    let startDateText: String = "Start date"
+    let finishDateText: String = "Finish date"
+    let saveButtonText: String = "save"
+    let cancelButtonText: String = "cancel"
     var body: some View {
         ZStack {
             background
@@ -87,7 +94,7 @@ struct EditSheetView: View {
                 .onTapGesture {
                     isShowingOverrideControls.toggle()
                 }
-            Text("Override settings")
+            Text(overrideSettingsHeaderText)
             Spacer()
         }
     }
@@ -113,23 +120,9 @@ struct EditSheetView: View {
     var editControls: some View {
         HStack {
             Button {
-                viewModel.saveEntry()
                 dismiss()
             } label: {
-                Text("SAVE")
-                    .font(.headline)
-                    .foregroundColor(.white)
-                    .frame(width: 140, height: 38)
-                    .background {
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(.blue)
-                    } // END OF BACKGROUND
-            } // END OF BUTTON
-            .accessibilityIdentifier(Identifier.Button.save.rawValue)
-            Button {
-                dismiss()
-            } label: {
-                Text("CANCEL")
+                Text(cancelButtonText.uppercased())
                     .font(.headline)
                     .foregroundColor(.white)
                     .frame(width: 140, height: 38)
@@ -139,14 +132,28 @@ struct EditSheetView: View {
                     } // END OF BACKGROUND
             } // END OF BUTTON
             .accessibilityIdentifier(Identifier.Button.cancel.rawValue)
+            Button {
+                viewModel.saveEntry()
+                dismiss()
+            } label: {
+                Text(saveButtonText.uppercased())
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .frame(width: 140, height: 38)
+                    .background {
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(.blue)
+                    } // END OF BACKGROUND
+            } // END OF BUTTON
+            .accessibilityIdentifier(Identifier.Button.save.rawValue)
         } // END OF HSTACK
     }
     
     var dateControls: some View {
         Group {
-            DatePicker("Start date", selection: $viewModel.startDate)
+            DatePicker(startDateText, selection: $viewModel.startDate)
                 .accessibilityIdentifier(Identifier.DatePicker.startDate.rawValue)
-            DatePicker("Finish date:", selection: $viewModel.finishDate)
+            DatePicker(finishDateText, selection: $viewModel.finishDate)
                 .accessibilityIdentifier(Identifier.DatePicker.finishDate.rawValue)
         }
     }
@@ -157,7 +164,7 @@ struct EditSheetView: View {
             RingView(startPoint: .constant(0), endPoint: $viewModel.overTimeFraction, ringColor: .green, ringWidth: 5, displayPointer: false)
                 .padding(10)
             VStack {
-                Text("work time".uppercased())
+                Text(timeIndicatorText.uppercased())
                     .font(.caption)
                 Text("04:20")
                     .font(.largeTitle)
@@ -167,7 +174,7 @@ struct EditSheetView: View {
     }
     
     var title: some View {
-        Text("Edit Entry")
+        Text(titleText)
             .font(.title)
     }
     

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -8,12 +8,11 @@
 import SwiftUI
 
 struct EditSheetView: View {
-    
-    private typealias Identifier = ScreenIdentifier.EditSheetView
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) var dismiss
     @StateObject var viewModel: EditSheetViewModel
     @State private var isShowingOverrideControls: Bool = false
+    private typealias Identifier = ScreenIdentifier.EditSheetView
     let regularTimeText: String = "Regular time"
     let overtimeText: String = "Overtime"
     let titleText: String = "Edit entry"
@@ -23,6 +22,7 @@ struct EditSheetView: View {
     let finishDateText: String = "Finish"
     let saveButtonText: String = "save"
     let cancelButtonText: String = "cancel"
+    
     var body: some View {
         ZStack {
             background
@@ -55,7 +55,22 @@ struct EditSheetView: View {
             .padding(.horizontal, 32)
         } // END OF ZSTACK
     } // END OF BODY
-    
+} // END OF STRUCT
+
+// MARK: VIEW BUILDERS
+extension EditSheetView {
+    @ViewBuilder
+    func dateControls() -> some View {
+        if !viewModel.shouldDisplayFullDates {
+            sameDayDateControls
+        } else {
+            diffDayDateControls
+        }
+    }
+}
+
+//MARK: OVERRIDE SETTINGS CONTROLS
+extension EditSheetView {
     var overrideControls: some View {
     //TODO: REPLACE PLACEHOLDERS WITH REAL VALUES
         Grid(alignment: .leading) {
@@ -87,77 +102,10 @@ struct EditSheetView: View {
             .padding(.trailing)
         }
     }
-    
-    var overrideSettingsHeader: some View {
-        HStack {
-            Image(systemName: "chevron.down")
-                .onTapGesture {
-                    isShowingOverrideControls.toggle()
-                }
-            Text(overrideSettingsHeaderText)
-            Spacer()
-        }
-    }
-    
-    var overtimeLabel: some View {
-            HStack {
-                Text(String(viewModel.overTimerString))
-                    .font(.title)
-                Text(overtimeText)
-                    .font(.caption)
-            }
-    }
-    
-    var regularTimeLabel: some View {
-            HStack {
-                Text(String(viewModel.workTimeString))
-                    .font(.title)
-                Text(regularTimeText)
-                    .font(.caption)
-            }
-    }
-    
-    var editControls: some View {
-        HStack {
-            Button {
-                dismiss()
-            } label: {
-                Text(cancelButtonText.uppercased())
-                    .font(.headline)
-                    .foregroundColor(.white)
-                    .frame(width: 140, height: 38)
-                    .background {
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(.gray)
-                    } // END OF BACKGROUND
-            } // END OF BUTTON
-            .accessibilityIdentifier(Identifier.Button.cancel.rawValue)
-            Button {
-                viewModel.saveEntry()
-                dismiss()
-            } label: {
-                Text(saveButtonText.uppercased())
-                    .font(.headline)
-                    .foregroundColor(.white)
-                    .frame(width: 140, height: 38)
-                    .background {
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(.blue)
-                    } // END OF BACKGROUND
-            } // END OF BUTTON
-            .accessibilityIdentifier(Identifier.Button.save.rawValue)
-        } // END OF HSTACK
-    }
-    
-    @ViewBuilder
-    func dateControls() -> some View {
-        if !viewModel.shouldDisplayFullDates {
-            sameDayDateControls
-        } else {
-            diffDayDateControls
-        }
-    }
-    
+}
+
+//MARK: DATE CONTROLS
+extension EditSheetView {
     var diffDayDateControls: some View {
         Group {
             DatePicker(startDateText, selection: $viewModel.startDate)
@@ -197,7 +145,10 @@ struct EditSheetView: View {
             }
         }
     }
-    
+}
+
+//MARK: TIME INDICATOR & LABELS
+extension EditSheetView {
     var timeIndicator: some View {
         ZStack {
             RingView(startPoint: .constant(0),endPoint: $viewModel.workTimeFraction, ringColor: .blue, ringWidth: 5,displayPointer: false)
@@ -213,15 +164,82 @@ struct EditSheetView: View {
         .frame(width: 250, height: 250)
     }
     
+    var overtimeLabel: some View {
+            HStack {
+                Text(String(viewModel.overTimerString))
+                    .font(.title)
+                Text(overtimeText)
+                    .font(.caption)
+            }
+    }
+    
+    var regularTimeLabel: some View {
+            HStack {
+                Text(String(viewModel.workTimeString))
+                    .font(.title)
+                Text(regularTimeText)
+                    .font(.caption)
+            }
+    }
+}
+
+//MARK: STATIC VIEW VAR
+extension EditSheetView {
     var title: some View {
         Text(titleText)
             .font(.title)
     }
     
+    var overrideSettingsHeader: some View {
+        HStack {
+            Image(systemName: "chevron.down")
+                .onTapGesture {
+                    isShowingOverrideControls.toggle()
+                }
+            Text(overrideSettingsHeaderText)
+            Spacer()
+        }
+    }
+    
     var background: some View {
         BackgroundFactory.buildSolidColor(.gray.opacity(0.1))
     }
-} // END OF STRUCT
+}
+
+//MARK: SAVE CONTROLS
+extension EditSheetView {
+    var editControls: some View {
+        HStack {
+            Button {
+                dismiss()
+            } label: {
+                Text(cancelButtonText.uppercased())
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .frame(width: 140, height: 38)
+                    .background {
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(.gray)
+                    } // END OF BACKGROUND
+            } // END OF BUTTON
+            .accessibilityIdentifier(Identifier.Button.cancel.rawValue)
+            Button {
+                viewModel.saveEntry()
+                dismiss()
+            } label: {
+                Text(saveButtonText.uppercased())
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .frame(width: 140, height: 38)
+                    .background {
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(.blue)
+                    } // END OF BACKGROUND
+            } // END OF BUTTON
+            .accessibilityIdentifier(Identifier.Button.save.rawValue)
+        } // END OF HSTACK
+    }
+}
 
 struct EditSheetView_Previews: PreviewProvider {
     private struct ContainerView: View {

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -169,8 +169,18 @@ extension EditSheetView {
 extension EditSheetView {
     var timeIndicator: some View {
         ZStack {
-            RingView(startPoint: .constant(0),endPoint: $viewModel.workTimeFraction, ringColor: .blue, ringWidth: 5,displayPointer: false)
-            RingView(startPoint: .constant(0), endPoint: $viewModel.overTimeFraction, ringColor: .green, ringWidth: 5, displayPointer: false)
+            RingView(startPoint: 0,
+                     endPoint: viewModel.workTimeFraction,
+                     ringColor: .blue,
+                     ringWidth: 5,
+                     displayPointer: false
+            )
+            RingView(startPoint: 0,
+                     endPoint: viewModel.overTimeFraction,
+                     ringColor: .green,
+                     ringWidth: 5,
+                     displayPointer: false
+            )
                 .padding(10)
             VStack {
                 Text(timeIndicatorText.uppercased())

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+//TODO: ADD CHECKING FOR BEFORE AND AFTER DATE IN THE PICKERS TO NOT LET CHOOSE A NEGATIVE INTERVAL <- THIS WILL CRASH THE APP
 struct EditSheetView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) var dismiss
@@ -194,7 +195,7 @@ extension EditSheetView {
     
     var overtimeLabel: some View {
             HStack {
-                Text(generateTimeIntervalLabel(value: TimeInterval(viewModel.overTimeInSeconds)))
+                Text(generateTimeIntervalLabel(value: viewModel.overTimeInSeconds))
                     .font(.title)
                 Text(overtimeText)
                     .font(.caption)
@@ -203,7 +204,7 @@ extension EditSheetView {
     
     var regularTimeLabel: some View {
             HStack {
-                Text(generateTimeIntervalLabel(value: TimeInterval(viewModel.workTimeInSeconds)))
+                Text(generateTimeIntervalLabel(value: viewModel.workTimeInSeconds))
                     .font(.title)
                 Text(regularTimeText)
                     .font(.caption)

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -22,6 +22,10 @@ struct EditSheetView: View {
     let finishDateText: String = "Finish"
     let saveButtonText: String = "save"
     let cancelButtonText: String = "cancel"
+    let maximumOvertimeText = "Maximum overtime"
+    let standardWorkTimeText = "Standard work time"
+    let grossPayPerMonthText = "Gross pay per month"
+    let calculateNetPayText = "Calculate net pay"
     
     var body: some View {
         ZStack {
@@ -72,32 +76,31 @@ extension EditSheetView {
 //MARK: OVERRIDE SETTINGS CONTROLS
 extension EditSheetView {
     var overrideControls: some View {
-    //TODO: REPLACE PLACEHOLDERS WITH REAL VALUES
         Grid(alignment: .leading) {
-            // row for overtime allowed in seconds
             GridRow {
-                Text("Maximum overtime")
-                TextField("Hours",
-                          text: .constant("5 hours"))
-                .textFieldStyle(.roundedBorder)
+                Text(maximumOvertimeText)
+                TimeIntervalPicker(buttonLabelText: viewModel.dateComponentFormatter.string(from: viewModel.currentMaximumOvertime) ?? "00:00",
+                                   hourComponent: $viewModel.maximumOvertime.0,
+                                   minuteComponent: $viewModel.maximumOvertime.1
+                )
             }
-            // row for standard worktime
+            
             GridRow {
-                Text("Standard work time")
-                TextField("Hours",
-                          text: .constant("8 hours"))
-                .textFieldStyle(.roundedBorder)
+                Text(standardWorkTimeText)
+                TimeIntervalPicker(buttonLabelText: viewModel.dateComponentFormatter.string(for: viewModel.currentStandardWorkTime) ?? "00:00",
+                                   hourComponent: $viewModel.standardWorkTime.0, minuteComponent: $viewModel.standardWorkTime.1
+                )
             }
-            // row for gross pay per mont
+            
             GridRow {
-                Text("Gross pay per month")
+                Text(grossPayPerMonthText)
                 TextField("PLN",
-                          text: .constant("10900"))
+                          text: $viewModel.grossPayPerMonth)
                 .textFieldStyle(.roundedBorder)
             }
-            // row for calculated net pay
+            
             Toggle(isOn: .constant(true)) {
-                Text("Calculate net pay")
+                Text(calculateNetPayText)
             }
             .padding(.trailing)
         }

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -13,15 +13,19 @@ struct EditSheetView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) var dismiss
     @StateObject var viewModel: EditSheetViewModel
-    @State private var isShowingOverrideControls: Bool = true//false
+    @State private var isShowingOverrideControls: Bool = false
     let regularTimeText: String = "Regular time"
     let overtimeText: String = "Overtime"
     var body: some View {
         ZStack {
             background
-            //TODO: REPLACE WITH SCROLLING VIEW
-            VStack {
-                title
+            
+            ScrollView {
+                HStack {
+                    title
+                    Spacer()
+                }
+                .padding(.top)
                 timeIndicator
                 .padding(.bottom)
                 regularTimeLabel
@@ -46,12 +50,12 @@ struct EditSheetView: View {
     } // END OF BODY
     var overrideSettingsHeader: some View {
         HStack {
-            Text("Override settings")
-            Spacer()
             Image(systemName: "chevron.down")
                 .onTapGesture {
                     isShowingOverrideControls.toggle()
                 }
+            Text("Override settings")
+            Spacer()
         }
     }
     var overtimeLabel: some View {
@@ -126,6 +130,12 @@ struct EditSheetView: View {
             RingView(startPoint: .constant(0),endPoint: $viewModel.workTimeFraction, ringColor: .blue, ringWidth: 5,displayPointer: false)
             RingView(startPoint: .constant(0), endPoint: $viewModel.overTimeFraction, ringColor: .green, ringWidth: 5, displayPointer: false)
                 .padding(10)
+            VStack {
+                Text("work time".uppercased())
+                    .font(.caption)
+                Text("04:20")
+                    .font(.largeTitle)
+            }
         }  // END OF ZSTACK
         .frame(width: 250, height: 250)
     }

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -26,7 +26,22 @@ struct EditSheetView: View {
     let standardWorkTimeText = "Standard work time"
     let grossPayPerMonthText = "Gross pay per month"
     let calculateNetPayText = "Calculate net pay"
+    //MARK: DATE FORMATTER
+    let dateComponentFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .positional
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.zeroFormattingBehavior = [.pad]
+        return formatter
+    }()
     
+    private func generateTimeIntervalLabel(value: TimeInterval) -> String {
+        return dateComponentFormatter.string(from: value) ?? "00:00"
+    }
+} // END OF STRUCT
+
+//MARK: BODY
+extension EditSheetView {
     var body: some View {
         ZStack {
             background
@@ -59,7 +74,7 @@ struct EditSheetView: View {
             .padding(.horizontal, 32)
         } // END OF ZSTACK
     } // END OF BODY
-} // END OF STRUCT
+}
 
 // MARK: VIEW BUILDERS
 extension EditSheetView {
@@ -79,7 +94,7 @@ extension EditSheetView {
         Grid(alignment: .leading) {
             GridRow {
                 Text(maximumOvertimeText)
-                TimeIntervalPicker(buttonLabelText: viewModel.dateComponentFormatter.string(from: viewModel.currentMaximumOvertime) ?? "00:00",
+                TimeIntervalPicker(buttonLabelText: dateComponentFormatter.string(from: viewModel.currentMaximumOvertime) ?? "00:00",
                                    hourComponent: $viewModel.maximumOvertime.0,
                                    minuteComponent: $viewModel.maximumOvertime.1
                 )
@@ -87,7 +102,7 @@ extension EditSheetView {
             
             GridRow {
                 Text(standardWorkTimeText)
-                TimeIntervalPicker(buttonLabelText: viewModel.dateComponentFormatter.string(for: viewModel.currentStandardWorkTime) ?? "00:00",
+                TimeIntervalPicker(buttonLabelText: dateComponentFormatter.string(for: viewModel.currentStandardWorkTime) ?? "00:00",
                                    hourComponent: $viewModel.standardWorkTime.0, minuteComponent: $viewModel.standardWorkTime.1
                 )
             }
@@ -160,7 +175,7 @@ extension EditSheetView {
             VStack {
                 Text(timeIndicatorText.uppercased())
                     .font(.caption)
-                Text(viewModel.totalTimeWorked)
+                Text(generateTimeIntervalLabel(value: viewModel.totalTimeInSeconds))
                     .font(.largeTitle)
             }
         }  // END OF ZSTACK
@@ -169,7 +184,7 @@ extension EditSheetView {
     
     var overtimeLabel: some View {
             HStack {
-                Text(String(viewModel.overTimerString))
+                Text(generateTimeIntervalLabel(value: TimeInterval(viewModel.overTimeInSeconds)))
                     .font(.title)
                 Text(overtimeText)
                     .font(.caption)
@@ -178,7 +193,7 @@ extension EditSheetView {
     
     var regularTimeLabel: some View {
             HStack {
-                Text(String(viewModel.workTimeString))
+                Text(generateTimeIntervalLabel(value: TimeInterval(viewModel.workTimeInSeconds)))
                     .font(.title)
                 Text(regularTimeText)
                     .font(.caption)

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -92,18 +92,18 @@ extension EditSheetView {
 extension EditSheetView {
     var overrideControls: some View {
         Grid(alignment: .leading) {
+            
             GridRow {
                 Text(maximumOvertimeText)
-                TimeIntervalPicker(buttonLabelText: dateComponentFormatter.string(from: viewModel.currentMaximumOvertime) ?? "00:00",
-                                   hourComponent: $viewModel.maximumOvertime.0,
-                                   minuteComponent: $viewModel.maximumOvertime.1
+                TimeIntervalPicker(buttonLabelText: generateTimeIntervalLabel(value: viewModel.currentMaximumOvertime),
+                                   value: $viewModel.currentMaximumOvertime
                 )
             }
             
             GridRow {
                 Text(standardWorkTimeText)
-                TimeIntervalPicker(buttonLabelText: dateComponentFormatter.string(for: viewModel.currentStandardWorkTime) ?? "00:00",
-                                   hourComponent: $viewModel.standardWorkTime.0, minuteComponent: $viewModel.standardWorkTime.1
+                TimeIntervalPicker(buttonLabelText: generateTimeIntervalLabel(value: viewModel.currentStandardWorkTime),
+                                   value: $viewModel.currentStandardWorkTime
                 )
             }
             

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -27,13 +27,7 @@ struct EditSheetView: View {
     let grossPayPerMonthText = "Gross pay per month"
     let calculateNetPayText = "Calculate net pay"
     //MARK: DATE FORMATTER
-    let dateComponentFormatter = {
-        let formatter = DateComponentsFormatter()
-        formatter.unitsStyle = .positional
-        formatter.allowedUnits = [.hour, .minute]
-        formatter.zeroFormattingBehavior = [.pad]
-        return formatter
-    }()
+    let dateComponentFormatter = FormatterFactory.makeDateComponentFormatter()
     
     
 } // END OF STRUCT

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -28,10 +28,14 @@ struct EditSheetView: View {
                 ScrollView {
                     timeIndicator
                         .padding(.bottom)
-                    regularTimeLabel
-                    overtimeLabel
-                        .padding(.bottom)
+                    HStack {
+                        regularTimeLabel
+                        Spacer()
+                        overtimeLabel
+                    }
+                    Divider()
                     dateControls
+                    Divider()
                     overrideSettingsHeader
                         .padding(.top)
                     if isShowingOverrideControls {
@@ -87,34 +91,25 @@ struct EditSheetView: View {
             Spacer()
         }
     }
+    
     var overtimeLabel: some View {
-        HStack {
-            Text(overtimeText)
-            Spacer()
-            Text(viewModel.overTimerString)
-                .accessibilityIdentifier(Identifier.Label.overtimeValue.rawValue)
-//                .padding(EdgeInsets(top: 4, leading: 28, bottom: 4, trailing: 28))
-//                .background {
-//                    Rectangle()
-//                        .cornerRadius(8)
-//                    .opacity(0.05)
-//                } // END OF BACKGROUND
-        } // END OF HSTACK
+            HStack {
+                Text(String(viewModel.overTimerString))
+                    .font(.title)
+                Text(overtimeText)
+                    .font(.caption)
+            }
     }
+    
     var regularTimeLabel: some View {
-        HStack {
-            Text(regularTimeText)
-            Spacer()
-            Text(viewModel.workTimeString)
-                .accessibilityIdentifier(Identifier.Label.timeWorkedValue.rawValue)
-//                .padding(EdgeInsets(top: 4, leading: 28, bottom: 4, trailing: 28))
-//                .background {
-//                    Rectangle()
-//                        .cornerRadius(8)
-//                    .opacity(0.05)
-//                } // END OF BACKGROUND
-        } // END OF HSTACK
+            HStack {
+                Text(String(viewModel.workTimeString))
+                    .font(.title)
+                Text(regularTimeText)
+                    .font(.caption)
+            }
     }
+    
     var editControls: some View {
         HStack {
             Button {
@@ -146,6 +141,7 @@ struct EditSheetView: View {
             .accessibilityIdentifier(Identifier.Button.cancel.rawValue)
         } // END OF HSTACK
     }
+    
     var dateControls: some View {
         Group {
             DatePicker("Start date", selection: $viewModel.startDate)
@@ -154,6 +150,7 @@ struct EditSheetView: View {
                 .accessibilityIdentifier(Identifier.DatePicker.finishDate.rawValue)
         }
     }
+    
     var timeIndicator: some View {
         ZStack {
             RingView(startPoint: .constant(0),endPoint: $viewModel.workTimeFraction, ringColor: .blue, ringWidth: 5,displayPointer: false)
@@ -168,10 +165,12 @@ struct EditSheetView: View {
         }  // END OF ZSTACK
         .frame(width: 250, height: 250)
     }
+    
     var title: some View {
         Text("Edit Entry")
             .font(.title)
     }
+    
     var background: some View {
         BackgroundFactory.buildSolidColor(.gray.opacity(0.1))
     }

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -19,28 +19,24 @@ struct EditSheetView: View {
     var body: some View {
         ZStack {
             background
-            
-            ScrollView {
+            VStack {
                 HStack {
                     title
                     Spacer()
                 }
                 .padding(.top)
-                timeIndicator
-                .padding(.bottom)
-                regularTimeLabel
-                overtimeLabel
-                    .padding(.bottom)
-                dateControls
-                overrideSettingsHeader
-                    .padding(.top)
-                if isShowingOverrideControls {
-                    Rectangle()
-                        .foregroundColor(.accentColor)
-                        .frame(height: 250)
-                        .overlay {
-                            Text("Override placeholder")
-                        }
+                ScrollView {
+                    timeIndicator
+                        .padding(.bottom)
+                    regularTimeLabel
+                    overtimeLabel
+                        .padding(.bottom)
+                    dateControls
+                    overrideSettingsHeader
+                        .padding(.top)
+                    if isShowingOverrideControls {
+                        overrideControls
+                    }
                 }
                 editControls
                 .padding(.top)
@@ -48,6 +44,39 @@ struct EditSheetView: View {
             .padding(.horizontal, 32)
         } // END OF ZSTACK
     } // END OF BODY
+    
+    var overrideControls: some View {
+    //TODO: REPLACE PLACEHOLDERS WITH REAL VALUES
+        Grid(alignment: .leading) {
+            // row for overtime allowed in seconds
+            GridRow {
+                Text("Maximum overtime")
+                TextField("Hours",
+                          text: .constant("5 hours"))
+                .textFieldStyle(.roundedBorder)
+            }
+            // row for standard worktime
+            GridRow {
+                Text("Standard work time")
+                TextField("Hours",
+                          text: .constant("8 hours"))
+                .textFieldStyle(.roundedBorder)
+            }
+            // row for gross pay per mont
+            GridRow {
+                Text("Gross pay per month")
+                TextField("PLN",
+                          text: .constant("10900"))
+                .textFieldStyle(.roundedBorder)
+            }
+            // row for calculated net pay
+            Toggle(isOn: .constant(true)) {
+                Text("Calculate net pay")
+            }
+            .padding(.trailing)
+        }
+    }
+    
     var overrideSettingsHeader: some View {
         HStack {
             Image(systemName: "chevron.down")

--- a/ClockIn/View/HistoryRow.swift
+++ b/ClockIn/View/HistoryRow.swift
@@ -114,8 +114,18 @@ struct HistoryRow: View {
         switch detailType {
         case .circleDisplay:
             ZStack {
-                RingView(startPoint: .constant(0), endPoint: .constant(workTime), ringColor: .blue, ringWidth: 5, displayPointer: false)
-                RingView(startPoint: .constant(0), endPoint: .constant(overTime), ringColor: .green, ringWidth: 5, displayPointer: false)
+                RingView(startPoint: 0, 
+                         endPoint: workTime,
+                         ringColor: .blue,
+                         ringWidth: 5,
+                         displayPointer: false
+                )
+                RingView(startPoint: 0,
+                         endPoint: overTime,
+                         ringColor: .green,
+                         ringWidth: 5,
+                         displayPointer: false
+                )
                     .padding(8)
             } // END OF ZSTACK
             .accessibilityIdentifier(Identifier.DetailView.circleDetail.rawValue)

--- a/ClockIn/View/HistoryView.swift
+++ b/ClockIn/View/HistoryView.swift
@@ -47,6 +47,7 @@ struct HistoryView: View {
                 EditSheetView(viewModel: 
                                 EditSheetViewModel(dataManager: container.dataManager,
                                                    settingsStore: container.settingsStore,
+                                                   payService: container.payManager,
                                                    entry: entry))
             } // END OF SHEET
             .sheet(isPresented: $isShowingFiltering) {

--- a/ClockIn/View/HomeView.swift
+++ b/ClockIn/View/HomeView.swift
@@ -105,8 +105,8 @@ extension HomeView {
     }
     
     var worktimeProgressRing: some View {
-        return RingView(startPoint: $viewModel.progress,
-                        endPoint: .constant(1),
+        return RingView(startPoint: viewModel.progress,
+                        endPoint: 1,
                         ringColor: .primary,
                         ringWidth: 5,
                         displayPointer: false)
@@ -115,8 +115,8 @@ extension HomeView {
     }
     
     var overtimeProgressRing: some View {
-            RingView(startPoint: .constant(0),
-                     endPoint: $viewModel.overtimeProgress,
+            RingView(startPoint: 0,
+                     endPoint: viewModel.overtimeProgress,
                      ringColor: .secondary,
                      ringWidth: 5,
                      displayPointer: false)

--- a/ClockIn/View/RingView.swift
+++ b/ClockIn/View/RingView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct RingView: View {
-    @Binding var startPoint: CGFloat
-    @Binding var endPoint: CGFloat
+    var startPoint: CGFloat
+    var endPoint: CGFloat
     
     var ringColor: Color
     var pointColor: Color?
@@ -69,8 +69,8 @@ struct RingView: View {
 struct RingView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            RingView(startPoint: .constant(0), 
-                     endPoint: .constant(0.4),
+            RingView(startPoint: 0, 
+                     endPoint: 0.4,
                      ringColor: .black)
                 .padding(.horizontal, 50)
         }

--- a/ClockIn/View/TimeIntervalPicker.swift
+++ b/ClockIn/View/TimeIntervalPicker.swift
@@ -9,9 +9,24 @@ import SwiftUI
 
 struct TimeIntervalPicker: View {
     let buttonLabelText: String
-    @Binding var hourComponent: Int
-    @Binding var minuteComponent: Int
     @State private var isShowingPickers: Bool = false
+    @Binding var value: TimeInterval
+    
+    var hourComponent: Binding<Int> {
+        Binding(get: {
+            Int(self.value) / 3600
+        }, set: { hours in
+            self.value = TimeInterval(hours * 3600 + self.minuteComponent.wrappedValue * 60)
+        })
+    }
+    
+    var minuteComponent: Binding<Int> {
+        Binding(get: {
+            Int(self.value) % 3600 / 60
+        }, set: { minutes in
+            self.value = TimeInterval(self.hourComponent.wrappedValue * 3600 + minutes * 60)
+        })
+    }
     
     var body: some View {
         Button {
@@ -26,7 +41,7 @@ struct TimeIntervalPicker: View {
         }
         .popover(isPresented: $isShowingPickers) {
             HStack {
-                Picker(selection: $hourComponent) {
+                Picker(selection: hourComponent) {
                     ForEach(0..<24, id: \.self) { i in
                         Text("\(i)").tag(i)
                     }
@@ -35,7 +50,7 @@ struct TimeIntervalPicker: View {
                 }
                 .frame(width: 100)
                 .pickerStyle(.wheel)
-                Picker(selection: $minuteComponent) {
+                Picker(selection: minuteComponent) {
                     ForEach(0..<60, id: \.self) { i in
                         Text("\(i)").tag(i)
                     }
@@ -53,7 +68,7 @@ struct TimeIntervalPicker: View {
 
 #Preview {
     TimeIntervalPicker(buttonLabelText: "01:30",
-                       hourComponent: .constant(1),
-                       minuteComponent: .constant(15)
+                       value: .constant(TimeInterval(integerLiteral: 1800 * 3)
+                                       )
     )
 }

--- a/ClockIn/View/TimeIntervalPicker.swift
+++ b/ClockIn/View/TimeIntervalPicker.swift
@@ -1,0 +1,59 @@
+//
+//  TimeIntervalPicker.swift
+//  ClockIn
+//
+//  Created by Tomasz Kubiak on 19/12/2023.
+//
+
+import SwiftUI
+
+struct TimeIntervalPicker: View {
+    let buttonLabelText: String
+    @Binding var hourComponent: Int
+    @Binding var minuteComponent: Int
+    @State private var isShowingPickers: Bool = false
+    
+    var body: some View {
+        Button {
+            isShowingPickers.toggle()
+        } label: {
+            Text(buttonLabelText)
+                .foregroundColor(.black)
+                .padding(.vertical, 8)
+                .padding(.horizontal,14)
+                .background(.gray.opacity(0.15))
+                .cornerRadius(10)
+        }
+        .popover(isPresented: $isShowingPickers) {
+            HStack {
+                Picker(selection: $hourComponent) {
+                    ForEach(0..<24, id: \.self) { i in
+                        Text("\(i)").tag(i)
+                    }
+                } label: {
+                    EmptyView()
+                }
+                .frame(width: 100)
+                .pickerStyle(.wheel)
+                Picker(selection: $minuteComponent) {
+                    ForEach(0..<60, id: \.self) { i in
+                        Text("\(i)").tag(i)
+                    }
+                } label: {
+                    EmptyView()
+                }
+                .frame(width: 100)
+                .pickerStyle(.wheel)
+            }
+            .presentationCompactAdaptation(.popover)
+        }
+    }
+}
+
+
+#Preview {
+    TimeIntervalPicker(buttonLabelText: "01:30",
+                       hourComponent: .constant(1),
+                       minuteComponent: .constant(15)
+    )
+}

--- a/ClockIn/ViewModel/EditShetViewModel.swift
+++ b/ClockIn/ViewModel/EditShetViewModel.swift
@@ -18,6 +18,13 @@ final class EditSheetViewModel: ObservableObject {
     private var overTimeAllowed: Int {
         settingsStore.maximumOvertimeAllowedInSeconds
     }
+    let dateComponentFormatter = { 
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .positional
+        formatter.allowedUnits = [.hour, .minute]
+        formatter.zeroFormattingBehavior = [.pad]
+        return formatter
+    }()
     
     @Published var startDate: Date {
         didSet {
@@ -32,18 +39,18 @@ final class EditSheetViewModel: ObservableObject {
     
     private var workTimeInSeconds: Int {
         didSet {
-            workTimeString = generateHoursString(value: workTimeInSeconds)
+            workTimeString = generateTimeIntervalLabel(value: TimeInterval(workTimeInSeconds))
             workTimeFraction = CGFloat(workTimeInSeconds) / CGFloat(workTimeAllowed)
         }
     }
     
-    
     private var overTimeInSeconds: Int {
         didSet {
-            overTimerString = generateHoursString(value: overTimeInSeconds)
+            overTimerString = generateTimeIntervalLabel(value: TimeInterval(overTimeInSeconds))
             overTimeFraction = CGFloat(overTimeInSeconds) / CGFloat(overTimeAllowed)
         }
     }
+    
     @Published var shouldDisplayFullDates: Bool = false
     @Published var totalTimeWorked: String
     @Published var workTimeString: String
@@ -68,9 +75,9 @@ final class EditSheetViewModel: ObservableObject {
         self.workTimeFraction = CGFloat(workTimeInSeconds) / CGFloat(settingsStore.workTimeInSeconds)
         self.overTimeFraction = CGFloat(overTimeInSeconds) / CGFloat(settingsStore.maximumOvertimeAllowedInSeconds)
         
-        self.workTimeString = generateHoursString(value: workTimeInSeconds)
-        self.overTimerString = generateHoursString(value: overTimeInSeconds)
-        self.totalTimeWorked = generateHoursString(value: workTimeInSeconds + overTimeInSeconds)
+        self.workTimeString = generateTimeIntervalLabel(value: TimeInterval(workTimeInSeconds))
+        self.overTimerString = generateTimeIntervalLabel(value: TimeInterval(overTimeInSeconds))
+        self.totalTimeWorked = generateTimeIntervalLabel(value: TimeInterval(workTimeInSeconds + overTimeInSeconds))
         
     }
     
@@ -87,9 +94,8 @@ final class EditSheetViewModel: ObservableObject {
         }
     }
     
-    private func generateHoursString(value: Int) -> String {
-        let resultValue: Double = Double(value) / 3600
-        return String(format: "%.2f", resultValue)
+    private func generateTimeIntervalLabel(value: TimeInterval) -> String {
+        return dateComponentFormatter.string(from: value)!
     }
     
     func saveEntry() {

--- a/ClockIn/ViewModel/EditShetViewModel.swift
+++ b/ClockIn/ViewModel/EditShetViewModel.swift
@@ -45,6 +45,7 @@ final class EditSheetViewModel: ObservableObject {
         }
     }
     @Published var shouldDisplayFullDates: Bool = false
+    @Published var totalTimeWorked: String
     @Published var workTimeString: String
     @Published var overTimerString: String
     @Published var workTimeFraction: CGFloat
@@ -60,6 +61,7 @@ final class EditSheetViewModel: ObservableObject {
         self.workTimeInSeconds = entry.workTimeInSeconds
         self.overTimeInSeconds = entry.overTimeInSeconds
         
+        self.totalTimeWorked = String()
         self.workTimeString = String()
         self.overTimerString = String()
 
@@ -68,7 +70,7 @@ final class EditSheetViewModel: ObservableObject {
         
         self.workTimeString = generateHoursString(value: workTimeInSeconds)
         self.overTimerString = generateHoursString(value: overTimeInSeconds)
-        
+        self.totalTimeWorked = generateHoursString(value: workTimeInSeconds + overTimeInSeconds)
         
     }
     

--- a/ClockIn/ViewModel/EditShetViewModel.swift
+++ b/ClockIn/ViewModel/EditShetViewModel.swift
@@ -21,14 +21,6 @@ final class EditSheetViewModel: ObservableObject {
         settingsStore.maximumOvertimeAllowedInSeconds
     }
     
-    // formatter should move to view since its responsible for view
-    let dateComponentFormatter = {
-        let formatter = DateComponentsFormatter()
-        formatter.unitsStyle = .positional
-        formatter.allowedUnits = [.hour, .minute]
-        formatter.zeroFormattingBehavior = [.pad]
-        return formatter
-    }()
     
     // placeholder properties
     @Published var startDate: Date {
@@ -42,27 +34,25 @@ final class EditSheetViewModel: ObservableObject {
         }
     }
     // placeholder properties created with calculate time? - need to remove side effects or set up as combine pipeline
-    private var workTimeInSeconds: Int {
+    @Published var workTimeInSeconds: Int {
         didSet {
-            workTimeString = generateTimeIntervalLabel(value: TimeInterval(workTimeInSeconds))
             workTimeFraction = CGFloat(workTimeInSeconds) / CGFloat(workTimeAllowed)
         }
     }
     
-    private var overTimeInSeconds: Int {
+    @Published var overTimeInSeconds: Int {
         didSet {
-            overTimerString = generateTimeIntervalLabel(value: TimeInterval(overTimeInSeconds))
             overTimeFraction = CGFloat(overTimeInSeconds) / CGFloat(overTimeAllowed)
         }
+    }
+    var totalTimeInSeconds: TimeInterval {
+        TimeInterval(workTimeInSeconds + overTimeInSeconds)
     }
     
     // should move to view?
     @Published var shouldDisplayFullDates: Bool = false
-    @Published var totalTimeWorked: String
-    @Published var workTimeString: String
-    @Published var overTimerString: String
-    @Published var workTimeFraction: CGFloat
-    @Published var overTimeFraction: CGFloat
+    @Published var workTimeFraction: CGFloat = .init()
+    @Published var overTimeFraction: CGFloat = .init()
     //think about joining the overtime properties or making it less spaghetti
     var currentMaximumOvertime: TimeInterval {
         TimeInterval(overTimeInSeconds)
@@ -101,17 +91,9 @@ final class EditSheetViewModel: ObservableObject {
         } else {
             self.calculateNetPay = false
         }
-        self.totalTimeWorked = String()
-        self.workTimeString = String()
-        self.overTimerString = String()
 
         self.workTimeFraction = CGFloat(workTimeInSeconds) / CGFloat(settingsStore.workTimeInSeconds)
         self.overTimeFraction = CGFloat(overTimeInSeconds) / CGFloat(settingsStore.maximumOvertimeAllowedInSeconds)
-        
-        self.workTimeString = generateTimeIntervalLabel(value: TimeInterval(workTimeInSeconds))
-        self.overTimerString = generateTimeIntervalLabel(value: TimeInterval(overTimeInSeconds))
-        self.totalTimeWorked = generateTimeIntervalLabel(value: TimeInterval(workTimeInSeconds + overTimeInSeconds))
-        
     }
     
     // calculating time intervals
@@ -126,10 +108,6 @@ final class EditSheetViewModel: ObservableObject {
                 overTimeInSeconds = seconds - workTimeAllowed
             }
         }
-    }
-    // move to view
-    private func generateTimeIntervalLabel(value: TimeInterval) -> String {
-        return dateComponentFormatter.string(from: value)!
     }
     
     // should stay but needs additional properties

--- a/ClockIn/ViewModel/EditShetViewModel.swift
+++ b/ClockIn/ViewModel/EditShetViewModel.swift
@@ -44,7 +44,7 @@ final class EditSheetViewModel: ObservableObject {
             overTimeFraction = CGFloat(overTimeInSeconds) / CGFloat(overTimeAllowed)
         }
     }
-    
+    @Published var shouldDisplayFullDates: Bool = false
     @Published var workTimeString: String
     @Published var overTimerString: String
     @Published var workTimeFraction: CGFloat

--- a/ClockIn/ViewModel/EditShetViewModel.swift
+++ b/ClockIn/ViewModel/EditShetViewModel.swift
@@ -33,8 +33,8 @@ final class EditSheetViewModel: ObservableObject {
     @Published var workTimeInSeconds: Int
     @Published var overTimeInSeconds: Int
     //think about joining the overtime properties or making it less spaghetti
-    var currentMaximumOvertime: TimeInterval
-    var currentStandardWorkTime: TimeInterval
+    @Published var currentMaximumOvertime: TimeInterval
+    @Published var currentStandardWorkTime: TimeInterval
     // stuff for overriding settings, it now overrides the actual time but let it live
     @Published var maximumOvertime = (Int(), Int()) {
         didSet {

--- a/ClockIn/ViewModel/EditShetViewModel.swift
+++ b/ClockIn/ViewModel/EditShetViewModel.swift
@@ -54,19 +54,19 @@ final class EditSheetViewModel: ObservableObject {
             .removeDuplicates()
             .sink { [weak self] date in
                 guard let self else { return }
-                self.calculateTime()
+                self.calculateTime(self.startDate, date)
             }.store(in: &cancellables)
         
         $startDate
             .removeDuplicates()
             .sink { [weak self] date in
                 guard let self else { return }
-                self.calculateTime()
+                self.calculateTime(date, self.finishDate)
             }.store(in: &cancellables)
     }
     
     // calculating time intervals
-    private func calculateTime() {
+    private func calculateTime(_ startDate: Date, _ finishDate: Date) {
         let interval = DateInterval(start: startDate, end: finishDate)
         if interval.duration <= currentStandardWorkTime {
             workTimeInSeconds = interval.duration
@@ -78,15 +78,16 @@ final class EditSheetViewModel: ObservableObject {
     }
     
     func saveEntry() {
-        //TODO: ADD SAVING ADDITIONAL OVERRIDE PROPERTIES
+        //TODO: ADD PAY SERVICE TO SAVE THE NET PAY
         entry.startDate = startDate
         entry.finishDate = finishDate
         entry.workTimeInSeconds = Int(workTimeInSeconds)
         entry.overTimeInSeconds = Int(overTimeInSeconds)
-        
-        
+        entry.maximumOvertimeAllowedInSeconds = Int(currentMaximumOvertime)
+        entry.standardWorktimeInSeconds = Int(currentMaximumOvertime)
+        entry.grossPayPerMonth = Int(grossPayPerMonth) ?? 0
+        entry.calculatedNetPay = calculateNetPay ? 0.0 : nil
         dataManager.updateAndSave(entry: entry)
-        
     }
     
 }

--- a/ClockIn/ViewModel/EditShetViewModel.swift
+++ b/ClockIn/ViewModel/EditShetViewModel.swift
@@ -27,8 +27,16 @@ final class EditSheetViewModel: ObservableObject {
     var totalTimeInSeconds: TimeInterval {
         TimeInterval(workTimeInSeconds + overTimeInSeconds)
     }
-    //MARK: GET PROPERTIES USED TO DRAW VIEWS <- MIGHT WANT TO MOVE TO VIEW
-    @Published var shouldDisplayFullDates: Bool = false
+    
+    var shouldDisplayFullDates: Bool {
+        if let hours = Calendar.current.dateComponents([.hour], from: startDate).hour {
+            if hours >= 16 {
+                return true
+            }
+        }
+        return false
+    }
+    
     var workTimeFraction: CGFloat {
         CGFloat(workTimeInSeconds / currentStandardWorkTime)
     }

--- a/ClockIn/ViewModel/EditShetViewModel.swift
+++ b/ClockIn/ViewModel/EditShetViewModel.swift
@@ -11,6 +11,7 @@ import Combine
 final class EditSheetViewModel: ObservableObject {
     private var dataManager: DataManager
     private var settingsStore: SettingsStore
+    private var payService: PayManager
     private var entry: Entry
     private let calendar: Calendar
     private var cancellables: Set<AnyCancellable> = .init()
@@ -44,9 +45,10 @@ final class EditSheetViewModel: ObservableObject {
         CGFloat(overTimeInSeconds / currentMaximumOvertime)
     }
     
-    init(dataManager: DataManager,  settingsStore: SettingsStore, entry: Entry, calendar: Calendar = .current) {
+    init(dataManager: DataManager,  settingsStore: SettingsStore, payService: PayManager, calendar: Calendar = .current, entry: Entry) {
         self.dataManager = dataManager
         self.settingsStore = settingsStore
+        self.payService = payService
         self.entry = entry
         self.calendar = calendar
         //assign values to draft properties
@@ -118,7 +120,6 @@ final class EditSheetViewModel: ObservableObject {
     }
     
     func saveEntry() {
-        //TODO: ADD PAY SERVICE TO SAVE THE NET PAY
         entry.startDate = startDate
         entry.finishDate = finishDate
         entry.workTimeInSeconds = Int(workTimeInSeconds)
@@ -126,7 +127,7 @@ final class EditSheetViewModel: ObservableObject {
         entry.maximumOvertimeAllowedInSeconds = Int(currentMaximumOvertime)
         entry.standardWorktimeInSeconds = Int(currentMaximumOvertime)
         entry.grossPayPerMonth = grossPayPerMonth
-        entry.calculatedNetPay = calculateNetPay ? 0.0 : nil
+        entry.calculatedNetPay = calculateNetPay ? payService.calculateNetPay(gross: Double(grossPayPerMonth)) : nil
         dataManager.updateAndSave(entry: entry)
     }
     

--- a/ClockIn/ViewModel/EditShetViewModel.swift
+++ b/ClockIn/ViewModel/EditShetViewModel.swift
@@ -21,8 +21,7 @@ final class EditSheetViewModel: ObservableObject {
     @Published var overTimeInSeconds: TimeInterval
     @Published var currentMaximumOvertime: TimeInterval
     @Published var currentStandardWorkTime: TimeInterval
-    //TODO: CHANGE TO INT PROPERTY WITH TEXTFIELD NUMBER ONLY
-    @Published var grossPayPerMonth = String()
+    @Published var grossPayPerMonth: Int
     @Published var calculateNetPay: Bool
     
     var totalTimeInSeconds: TimeInterval {
@@ -57,7 +56,7 @@ final class EditSheetViewModel: ObservableObject {
         self.overTimeInSeconds = TimeInterval(entry.overTimeInSeconds)
         self.currentMaximumOvertime = TimeInterval(entry.maximumOvertimeAllowedInSeconds)
         self.currentStandardWorkTime = TimeInterval(entry.standardWorktimeInSeconds)
-        self.grossPayPerMonth = String(entry.grossPayPerMonth)
+        self.grossPayPerMonth = entry.grossPayPerMonth
         self.calculateNetPay = entry.calculatedNetPay == nil ? false : true
         // set up combine subscribers
         $finishDate
@@ -126,7 +125,7 @@ final class EditSheetViewModel: ObservableObject {
         entry.overTimeInSeconds = Int(overTimeInSeconds)
         entry.maximumOvertimeAllowedInSeconds = Int(currentMaximumOvertime)
         entry.standardWorktimeInSeconds = Int(currentMaximumOvertime)
-        entry.grossPayPerMonth = Int(grossPayPerMonth) ?? 0
+        entry.grossPayPerMonth = grossPayPerMonth
         entry.calculatedNetPay = calculateNetPay ? 0.0 : nil
         dataManager.updateAndSave(entry: entry)
     }

--- a/ClockInTests/EditSheetViewModelTests.swift
+++ b/ClockInTests/EditSheetViewModelTests.swift
@@ -1,0 +1,55 @@
+//
+//  EditSheetViewModelTests.swift
+//  ClockInTests
+//
+//  Created by Tomasz Kubiak on 21/12/2023.
+//
+
+import XCTest
+@testable import ClockIn
+
+final class EditSheetViewModelTests: XCTestCase {
+    
+    var sut: EditSheetViewModel!
+    let entry: Entry = {
+        let startOfDay = Calendar.current.startOfDay(for: Date())
+        let startDate = Calendar.current.date(byAdding: .hour, value: 6, to: startOfDay)!
+        let finishDate = Calendar.current.date(byAdding: .minute,
+                                               value: 9 * 60 + 30,
+                                               to: startDate)!
+        return Entry(startDate: startDate,
+                     finishDate: finishDate,
+                     workTimeInSec: 8*3600,
+                     overTimeInSec: 3600 + 1800,
+                     maximumOvertimeAllowedInSeconds: 5*3600,
+                     standardWorktimeInSeconds: 8*3600,
+                     grossPayPerMonth: 10000,
+                     calculatedNetPay: nil)
+    }()
+    
+    override func setUp() {
+        
+        SettingsStore.setTestUserDefaults()
+        let settingStore = SettingsStore()
+        
+        sut = .init(dataManager: .testing, settingsStore: settingStore, entry: entry, calendar: .current)
+    }
+
+    override func tearDown() {
+        SettingsStore.clearUserDefaults()
+        sut = nil
+    }
+
+    func test_adjustToEqualDateComponents() throws {
+        //Given
+        guard let inputDate = Calendar.current.date(byAdding: .day, value: -1, to: sut.startDate),
+              let expectedFinishDate = Calendar.current.date(byAdding: .day, value: -1, to: sut.finishDate) else {
+            XCTFail("Failed to generate input and expected date in \(#file), function: \(#function), at line \(#line)")
+            return
+        }
+        //When
+        sut.startDate = inputDate
+        //Then
+        XCTAssertEqual(expectedFinishDate, sut.finishDate, "Dates should be equal")
+    }
+}


### PR DESCRIPTION
This PR adds overriding settings in editing entry allowing user to edit additional entry data added in #16. 
Additionally view was updated to match the structure of figma design, in preparation for UI overhaul. 
EditSheetView and view model was refactored and simplified to improve readability.

