### PR TITLE
Move home vm timer to service

### DIFF
--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		D61945F029E735D80046DE1F /* MockTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61945EF29E735D80046DE1F /* MockTimer.swift */; };
 		D61F11312AB38F8700902D6D /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61F11302AB38F8700902D6D /* SettingsStore.swift */; };
 		D61F11342AB3A6FF00902D6D /* ColorScheme+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61F11332AB3A6FF00902D6D /* ColorScheme+Extension.swift */; };
+		D629CEF92B3613660036579D /* TimerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D629CEF82B3613660036579D /* TimerService.swift */; };
 		D64313B82B1E606B003B5DBC /* PreviewDataFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64313B72B1E606B003B5DBC /* PreviewDataFactory.swift */; };
 		D64574B029D9E6A000207168 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574AF29D9E6A000207168 /* DataManager.swift */; };
 		D64574B329D9F16900207168 /* EntryMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574B129D9F16900207168 /* EntryMO+CoreDataClass.swift */; };
@@ -118,6 +119,7 @@
 		D61945EF29E735D80046DE1F /* MockTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTimer.swift; sourceTree = "<group>"; };
 		D61F11302AB38F8700902D6D /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
 		D61F11332AB3A6FF00902D6D /* ColorScheme+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColorScheme+Extension.swift"; sourceTree = "<group>"; };
+		D629CEF82B3613660036579D /* TimerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerService.swift; sourceTree = "<group>"; };
 		D64313B72B1E606B003B5DBC /* PreviewDataFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDataFactory.swift; sourceTree = "<group>"; };
 		D64574AF29D9E6A000207168 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		D64574B129D9F16900207168 /* EntryMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EntryMO+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -387,6 +389,7 @@
 			children = (
 				D64574B129D9F16900207168 /* EntryMO+CoreDataClass.swift */,
 				D64574B229D9F16900207168 /* EntryMO+CoreDataProperties.swift */,
+				D629CEF82B3613660036579D /* TimerService.swift */,
 				D65FD53C29D8B259006CC34F /* PersistanceController.swift */,
 				D64574AF29D9E6A000207168 /* DataManager.swift */,
 				D64574B529D9F37400207168 /* Entry.swift */,
@@ -569,6 +572,7 @@
 				D6CBB86A2B34C7150074CE8B /* FormatterFactory.swift in Sources */,
 				D61F11312AB38F8700902D6D /* SettingsStore.swift in Sources */,
 				D6842EC029EC178000731E84 /* StatisticsView.swift in Sources */,
+				D629CEF92B3613660036579D /* TimerService.swift in Sources */,
 				D66750EC29D71C8300757F17 /* HistoryRow.swift in Sources */,
 				D6EA695A2AF83E7800D8F6C3 /* OnboardingWorktimeView.swift in Sources */,
 				D65A976D29F323A900462D8C /* K.swift in Sources */,

--- a/ClockIn.xcodeproj/project.pbxproj
+++ b/ClockIn.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		D61F11312AB38F8700902D6D /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61F11302AB38F8700902D6D /* SettingsStore.swift */; };
 		D61F11342AB3A6FF00902D6D /* ColorScheme+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61F11332AB3A6FF00902D6D /* ColorScheme+Extension.swift */; };
 		D629CEF92B3613660036579D /* TimerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D629CEF82B3613660036579D /* TimerService.swift */; };
+		D629CEFB2B363B500036579D /* TimerServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D629CEFA2B363B500036579D /* TimerServiceTests.swift */; };
 		D64313B82B1E606B003B5DBC /* PreviewDataFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64313B72B1E606B003B5DBC /* PreviewDataFactory.swift */; };
 		D64574B029D9E6A000207168 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574AF29D9E6A000207168 /* DataManager.swift */; };
 		D64574B329D9F16900207168 /* EntryMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64574B129D9F16900207168 /* EntryMO+CoreDataClass.swift */; };
@@ -120,6 +121,7 @@
 		D61F11302AB38F8700902D6D /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
 		D61F11332AB3A6FF00902D6D /* ColorScheme+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ColorScheme+Extension.swift"; sourceTree = "<group>"; };
 		D629CEF82B3613660036579D /* TimerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerService.swift; sourceTree = "<group>"; };
+		D629CEFA2B363B500036579D /* TimerServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimerServiceTests.swift; path = ClockInTests/TimerServiceTests.swift; sourceTree = "<group>"; };
 		D64313B72B1E606B003B5DBC /* PreviewDataFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDataFactory.swift; sourceTree = "<group>"; };
 		D64574AF29D9E6A000207168 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		D64574B129D9F16900207168 /* EntryMO+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EntryMO+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -263,6 +265,7 @@
 		D6C4588729D229200069D89B = {
 			isa = PBXGroup;
 			children = (
+				D629CEFA2B363B500036579D /* TimerServiceTests.swift */,
 				D6C4589229D229210069D89B /* ClockIn */,
 				D6C458A329D229230069D89B /* ClockInTests */,
 				D6C458AD29D229230069D89B /* ClockInUITests */,
@@ -598,6 +601,7 @@
 				D65A976B29F2E6B800462D8C /* StatisticsViewModelTests.swift in Sources */,
 				D61945EC29E7306B0046DE1F /* HomeViewModelTests.swift in Sources */,
 				D60480D82B122CDA00D6D70D /* ChartPeriodServiceTests.swift in Sources */,
+				D629CEFB2B363B500036579D /* TimerServiceTests.swift in Sources */,
 				D61945F029E735D80046DE1F /* MockTimer.swift in Sources */,
 				D6C458A529D229230069D89B /* ClockInTests.swift in Sources */,
 				D6CBB8662B3443360074CE8B /* EditSheetViewModelTests.swift in Sources */,

--- a/ClockIn/Model/ScreenIdentifier.swift
+++ b/ClockIn/Model/ScreenIdentifier.swift
@@ -15,7 +15,9 @@ enum ScreenIdentifier {
         case history
     }
     enum HomeView: String {
-        case startPauseButton
+        case startButton
+        case pauseButton
+        case resumeButton
         case finishButton
         case timerLabel
         case settingNavigationButton

--- a/ClockIn/Model/TimerService.swift
+++ b/ClockIn/Model/TimerService.swift
@@ -21,7 +21,7 @@ class TimerService: ObservableObject {
     private let timerLimit: TimeInterval
     
     //Published progress properties for UI
-    @Published var progressToFirstLimit: CGFloat = 0.0
+    @Published var progress: CGFloat = 0.0
     @Published private(set) var serviceState: TimerServiceState = .notStarted
     private(set) var counter: TimeInterval = 0
     
@@ -63,7 +63,7 @@ class TimerService: ObservableObject {
     
     private func startTimer()  {
         counter = 0
-        progressToFirstLimit = 0
+        progress = 0
         timer = timerProvider.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
             guard let self else { return }
             self.updateTimer()
@@ -83,6 +83,6 @@ class TimerService: ObservableObject {
     }
     
     private func updateProgressCounter() {
-        progressToFirstLimit = CGFloat(counter / timerLimit)
+        progress = CGFloat(counter / timerLimit)
     }
 }

--- a/ClockIn/Model/TimerService.swift
+++ b/ClockIn/Model/TimerService.swift
@@ -68,7 +68,7 @@ class TimerService: ObservableObject {
         counter = 0
         progress = 0
         serviceState = .running
-        timer = timerProvider.scheduledTimer(withTimeInterval: 0.01, repeats: true, block: { [weak self] _ in
+        timer = timerProvider.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
             guard let self else { return }
             self.updateTimer()
         })
@@ -80,7 +80,7 @@ class TimerService: ObservableObject {
         withAnimation(.easeInOut) {
             updateProgressCounter()
         }
-        if counter == timerLimit {
+        if counter >= timerLimit {
             self.serviceState = .finished
         }
     }

--- a/ClockIn/Model/TimerService.swift
+++ b/ClockIn/Model/TimerService.swift
@@ -23,7 +23,10 @@ class TimerService: ObservableObject {
     //Published progress properties for UI
     @Published var progress: CGFloat = 0.0
     @Published private(set) var serviceState: TimerServiceState = .notStarted
-    private(set) var counter: TimeInterval = 0
+    @Published private(set) var counter: TimeInterval = 0
+    var remainingTime: TimeInterval {
+        timerLimit - counter
+    }
     
     init(timerProvider: Timer.Type, timerLimit: TimeInterval) {
         self.timerLimit = timerLimit
@@ -64,11 +67,11 @@ class TimerService: ObservableObject {
     private func startTimer()  {
         counter = 0
         progress = 0
-        timer = timerProvider.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
+        serviceState = .running
+        timer = timerProvider.scheduledTimer(withTimeInterval: 0.01, repeats: true, block: { [weak self] _ in
             guard let self else { return }
             self.updateTimer()
         })
-        serviceState = .running
     }
     
     private func updateTimer(byAdding addValue: TimeInterval = 1) {

--- a/ClockIn/Model/TimerService.swift
+++ b/ClockIn/Model/TimerService.swift
@@ -29,10 +29,10 @@ class TimerService: ObservableObject {
     
     //MARK: COUNTDOWN TIMER PROPERTIES - PRIVATE
     // this is set at the begining to the limit and the counted down
-    private var firstCounter: TimeInterval = 0
+    private(set) var firstCounter: TimeInterval = 0
     //MARK: OVERTIME TIME PROPERTIES - PRIVATE
     // this is set at the begining to 0 and then added to
-    private var secondCounter: TimeInterval  = 0
+    private(set) var secondCounter: TimeInterval  = 0
     
     init(timerProvider: Timer.Type, timerLimit: TimeInterval, timerSecondLimit: TimeInterval, progressAfterLimit: Bool) {
         self.timerLimit = timerLimit

--- a/ClockIn/Model/TimerService.swift
+++ b/ClockIn/Model/TimerService.swift
@@ -1,0 +1,117 @@
+//
+//  TimerService.swift
+//  ClockIn
+//
+//  Created by Tomasz Kubiak on 22/12/2023.
+//
+
+import Foundation
+import SwiftUI
+
+class TimerService: ObservableObject {
+    private enum TimerServiceState {
+        case running, paused, stopped
+    }
+    private var timerProvider: Timer.Type
+    private var timer: Timer?
+    private let timerLimit: TimeInterval
+    private let timerSecondLimit: TimeInterval
+    private let progressAfterFinish: Bool
+    private var serviceState: TimerServiceState = .stopped
+    //Published progress properties for UI
+    //Value for display, maybe these can be get properties
+    @Published var progressToFirstLimit: CGFloat = 0.0
+    @Published var progressToSecondLimit: CGFloat = 0.0
+
+    //Timer state properties
+    @Published var isStarted: Bool = false
+    @Published var isRunning: Bool = false
+    
+    //MARK: COUNTDOWN TIMER PROPERTIES - PRIVATE
+    // this is set at the begining to the limit and the counted down
+    private var firstCounter: TimeInterval = 0
+    //MARK: OVERTIME TIME PROPERTIES - PRIVATE
+    // this is set at the begining to 0 and then added to
+    private var secondCounter: TimeInterval  = 0
+    
+    init(timerProvider: Timer.Type, timerLimit: TimeInterval, timerSecondLimit: TimeInterval, progressAfterLimit: Bool) {
+        self.timerLimit = timerLimit
+        self.timerSecondLimit = timerSecondLimit
+        self.timerProvider = timerProvider
+        self.progressAfterFinish = progressAfterLimit
+    }
+    
+    // start & stop
+    func startTimer()  {
+        if serviceState == .stopped {
+            firstCounter = timerLimit
+            secondCounter = 0
+            
+            progressToFirstLimit = 0
+            progressToSecondLimit = 0
+            // this still does not work in the background
+            timer = timerProvider.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
+                guard let self else { return }
+                self.updateTimer()
+            })
+            isStarted = true
+            isRunning = true
+            serviceState = .running
+        }
+        if serviceState == .paused {
+            serviceState = .running
+        }
+    }
+    
+    func stopTimer() {
+        if let timer = timer {
+            timer.invalidate()
+        }
+        isStarted = false
+        isRunning = false
+        serviceState = .stopped
+    }
+    
+    func pauseTimer() {
+        serviceState = .paused
+    }
+    // timer updates
+    /**
+     Updates the timer countdown value
+     - Parameter subtrahend: The value to be substracted from the countdown (default is 1)
+     */
+    func updateTimer(subtract subtrahend: TimeInterval = 1) {
+        if isStarted && isRunning {
+            
+            //This is the situation when the timer is still in current state after the update, including 0
+            if firstCounter >= subtrahend {
+                firstCounter -= subtrahend
+                withAnimation(.easeInOut) {
+                    progressToFirstLimit = 1 - CGFloat(firstCounter) / CGFloat(timerLimit)
+                }
+                
+                return
+            }
+            //this is the situation when timer value moves it into overtime
+            if firstCounter < subtrahend {
+                if progressAfterFinish {
+                    firstCounter = 0
+                    secondCounter += subtrahend - firstCounter
+                    //update the progress rings
+                    withAnimation(.easeInOut) {
+                        progressToFirstLimit = 1 - CGFloat(firstCounter) / CGFloat(timerLimit)
+                        progressToSecondLimit = CGFloat(secondCounter) / CGFloat(timerSecondLimit)
+                    }
+                    
+                } else {
+                    firstCounter = 0
+                    withAnimation(.easeInOut) {
+                        progressToFirstLimit = 1 - CGFloat(firstCounter) / CGFloat(timerLimit)
+                    }
+                    
+                    stopTimer()
+                }
+            }
+        }
+    }
+}

--- a/ClockIn/View/HomeView.swift
+++ b/ClockIn/View/HomeView.swift
@@ -13,6 +13,8 @@ struct HomeView: View {
     @StateObject private var viewModel: HomeViewModel
     @EnvironmentObject private var container: Container
     let timerIndicatorFormatter = FormatterFactory.makeDateComponentFormatter()
+    let titleText: String = "ClockIn"
+    let settingText: String = "Settings"
     init(viewModel: HomeViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
     }
@@ -22,10 +24,10 @@ struct HomeView: View {
             background
             VStack(spacing: 64) {
                 timerIndicator
-                controlButtons
+                makeControls(viewModel.state)
             } // END OF VSTACK
         } // END OF ZSTACK
-        .navigationTitle("ClockIn")
+        .navigationTitle(titleText)
         .toolbar { toolbar }
     } // END OF BODY
     
@@ -39,9 +41,10 @@ struct HomeView: View {
                 SettingsView(viewModel:
                                 SettingsViewModel(
                                     dataManger: container.dataManager,
-                                    settingsStore: container.settingsStore))
+                                    settingsStore: container.settingsStore
+                                ))
             } label: {
-                Label("Settings", systemImage: "gearshape.fill")
+                Label(settingText, systemImage: "gearshape.fill")
             } // END OF NAV LINK
             .tint(.primary)
             .accessibilityIdentifier(Identifier.settingNavigationButton.rawValue)
@@ -51,12 +54,21 @@ struct HomeView: View {
 
 //MARK: - TIMER CONTROLS
 extension HomeView {
-    var controlButtons: some View {
-        HStack(spacing: 50) {
-            if viewModel.state == .running {
+    @ViewBuilder
+    func makeControls(_ state: TimerService.TimerServiceState) -> some View {
+        switch state {
+        case .running:
+            HStack(spacing: 50) {
+                pauseButton
                 finishButton
-            } // END OF IF
-            startPauseButton
+            }
+        case .paused:
+            HStack(spacing: 50) {
+                resumeButton
+                finishButton
+            }
+        case .notStarted, .finished:
+            startButton
         }
     }
     
@@ -72,21 +84,38 @@ extension HomeView {
         .accessibilityIdentifier(Identifier.finishButton.rawValue)
     }
     
-    var startPauseButton: some View {
+    var startButton: some View {
         Button {
-            switch viewModel.state {
-            case .running:
-                viewModel.pauseTimerService()
-            case .notStarted, .paused, .finished:
-                viewModel.startTimerService()
-            }
-             // resume signal
-            
+            viewModel.startTimerService()
         } label: {
             Image(systemName: viewModel.state  == .running ? "pause.fill" : "play.fill")
                 .resizable()
         } // END OF BUTTON
-        .accessibilityIdentifier(Identifier.startPauseButton.rawValue)
+        .accessibilityIdentifier(Identifier.startButton.rawValue)
+        .accentColor(.primary)
+        .frame(width: 50, height: 50)
+    }
+    
+    var resumeButton: some View {
+        Button {
+            viewModel.resumeTimerService()
+        } label: {
+            Image(systemName: "play.fill")
+                .resizable()
+        } // END OF BUTTON
+        .accessibilityIdentifier(Identifier.resumeButton.rawValue)
+        .accentColor(.primary)
+        .frame(width: 50, height: 50)
+    }
+    
+    var pauseButton: some View {
+        Button {
+            viewModel.pauseTimerService()
+        } label: {
+            Image(systemName: "pause.fill")
+                .resizable()
+        } // END OF BUTTON
+        .accessibilityIdentifier(Identifier.pauseButton.rawValue)
         .accentColor(.primary)
         .frame(width: 50, height: 50)
     }
@@ -98,9 +127,9 @@ extension HomeView {
         ZStack {
             timerLabel
             worktimeProgressRing
-//            if viewModel.overtimeProgress > 0 {
-//                overtimeProgressRing
-//            }
+            if viewModel.overtimeProgress > 0 {
+                overtimeProgressRing
+            }
         }
     }
     
@@ -116,19 +145,22 @@ extension HomeView {
                         endPoint: viewModel.normalProgress,
                         ringColor: .primary,
                         ringWidth: 5,
-                        displayPointer: false)
+                        displayPointer: false
+        )
             .frame(width: UIScreen.main.bounds.size.width-120,
                    height: UIScreen.main.bounds.size.width-120)
     }
     
-//    var overtimeProgressRing: some View {
-//            RingView(startPoint: 0,
-//                     endPoint: viewModel.overtimeProgress,
-//                     ringColor: .secondary,
-//                     ringWidth: 5,
-//                     displayPointer: false)
-//                .frame(width: UIScreen.main.bounds.size.width-120, height: UIScreen.main.bounds.size.width-120)
-//    }
+    var overtimeProgressRing: some View {
+            RingView(startPoint: 0,
+                     endPoint: viewModel.overtimeProgress,
+                     ringColor: .red,
+                     ringWidth: 5,
+                     displayPointer: false
+            )
+                .frame(width: UIScreen.main.bounds.size.width-120,
+                       height: UIScreen.main.bounds.size.width-120)
+    }
     func formatTimeInterval(_ value: TimeInterval) -> String {
         return timerIndicatorFormatter.string(from: value) ?? "\(value)"
     }

--- a/ClockIn/ViewModel/HomeViewModel.swift
+++ b/ClockIn/ViewModel/HomeViewModel.swift
@@ -7,10 +7,11 @@
 
 import SwiftUI
 import Combine
+//TODO: Resume from background does not work on second timer - move to VM
+//TODO: fix bug when time in background is bigger than timer limit - first timer never emits finish - move to VM
+//TODO: Remove bug when timer is not saving entry when not stopped with button - move to VM
 
 class HomeViewModel: NSObject, ObservableObject {
-    
-    //MARK: DATA MANAGING PROPERTIES
     private var dataManager: DataManager
     private var settingsStore: SettingsStore
     private var payManager: PayManager
@@ -18,16 +19,29 @@ class HomeViewModel: NSObject, ObservableObject {
     private var finishDate: Date?
     private var appDidEnterBackgroundDate: Date?
     private var subscriptions = Set<AnyCancellable>()
-    //TIMER
     private var timerProvider: Timer.Type = Timer.self
     private var workTimerService: TimerService
-    
+    private var overtimeTimerService: TimerService?
     @Published var state: TimerService.TimerServiceState = .notStarted
+    
     var timerDisplayValue: TimeInterval {
-        return workTimerService.counter
+        if let overtimeTimerService = overtimeTimerService {
+            if overtimeTimerService.progress > 0 {
+                return overtimeTimerService.counter
+            } else {
+                return workTimerService.counter
+            }
+        } else {
+            return workTimerService.counter
+        }
     }
+    
     var normalProgress: CGFloat {
         return workTimerService.progress
+    }
+    
+    var overtimeProgress: CGFloat {
+        return overtimeTimerService?.progress ?? 0
     }
     
     init(dataManager: DataManager, settingsStore: SettingsStore, payManager: PayManager ,timerProvider: Timer.Type) {
@@ -40,26 +54,51 @@ class HomeViewModel: NSObject, ObservableObject {
             timerProvider: timerProvider,
             timerLimit: TimeInterval(settingsStore.workTimeInSeconds)
         )
+        if self.settingsStore.isLoggingOvertime {
+            self.overtimeTimerService = .init(
+                timerProvider: timerProvider,
+                timerLimit: TimeInterval(settingsStore.maximumOvertimeAllowedInSeconds))
+        }
         super.init()
         setAppStateObservers()
         setUpTimerSubscribers()
     }
+    
     private func setUpTimerSubscribers() {
         self.workTimerService.objectWillChange.sink { _ in
             self.objectWillChange.send()
         }.store(in: &subscriptions)
         
-        // this is a subscriber for saving when timer is set to finished
-        self.workTimerService.$serviceState.filter { state in
-            return state == .finished
-        }.sink { [weak self] _ in
-            self?.saveEntry()
+        self.overtimeTimerService?.objectWillChange.sink { _ in
+            self.objectWillChange.send()
         }.store(in: &subscriptions)
+        
+        if let overtimeTimerService = self.overtimeTimerService {
+            self.workTimerService.$serviceState.filter { state in
+                state == .finished
+            }.sink { [weak self] _ in
+                self?.overtimeTimerService?.send(event: .start)
+            }.store(in: &subscriptions)
+            
+            overtimeTimerService.$serviceState.filter { state in
+                return state == .finished
+            }.sink { [weak self] _ in
+                self?.saveEntry()
+            }.store(in: &subscriptions)
+        } else {
+            self.workTimerService.$serviceState.filter { state in
+                return state == .finished
+            }.sink { [weak self] _ in
+                
+                self?.saveEntry()
+            }.store(in: &subscriptions)
+        }
     }
 }
 
 //MARK: TIMER INTERFACE
 extension HomeViewModel {
+    // should start a new timer
     func startTimerService() {
         if workTimerService.serviceState == .finished {
             workTimerService = .init(
@@ -78,14 +117,19 @@ extension HomeViewModel {
     func pauseTimerService() {
         self.state = .paused
         workTimerService.send(event: .pause)
+        overtimeTimerService?.send(event: .pause)
     }
-    
+    func resumeTimerService() {
+        self.state = .running
+        workTimerService.send(event: .resumeWith(nil))
+        overtimeTimerService?.send(event: .resumeWith(nil))
+    }
     func stopTimerService() {
         self.state = .notStarted
-        workTimerService.send(event: .stop)
         finishDate = Date()
+        workTimerService.send(event: .stop)
+        overtimeTimerService?.send(event: .stop)
     }
-    
     func resumeFromBackground(_ appDidEnterBackgroundDate: Date) {
         let timePassedInBackground = DateInterval(start: appDidEnterBackgroundDate, end: Date()).duration
         workTimerService.send(event: .resumeWith(timePassedInBackground))

--- a/ClockIn/ViewModel/HomeViewModel.swift
+++ b/ClockIn/ViewModel/HomeViewModel.swift
@@ -218,7 +218,7 @@ extension HomeViewModel {
     
 }
 
-    //MARK: DATA OPERATIONS
+//MARK: DATA OPERATIONS
 extension HomeViewModel {
     
     func saveEntry() {

--- a/ClockIn/ViewModel/HomeViewModel.swift
+++ b/ClockIn/ViewModel/HomeViewModel.swift
@@ -16,71 +16,82 @@ class HomeViewModel: NSObject, ObservableObject {
     private var payManager: PayManager
     private var startDate: Date?
     private var finishDate: Date?
-    private var subscriptions = Set<AnyCancellable>()
-    //MARK: TIMER PROPERTIES - PUBLISHED
-    //Published progress properties for UI
-    @Published var progress: CGFloat = 0.0
-    @Published var overtimeProgress: CGFloat = 0.0
-    //Value for display
-    @Published var timerStringValue: String = "00:00"
-    
-    @Published var secondProgress: CGFloat = 0.0
-    @Published var minuteProgress: CGFloat = 0.0
-    
-    //Timer state properties
-    @Published var isStarted: Bool = false
-    @Published var isRunning: Bool = false
-    @Published var progressAfterFinish: Bool = true
-    
-    //MARK: COUNTDOWN TIMER PROPERTIES - PRIVATE
-    private var timerProvider: Timer.Type = Timer.self
-    private var timer: Timer?
-    private var countSeconds: Int = 0
-    private var currentHours: Int {
-        return countSeconds/3600
-    }
-    private var currentMinutes: Int {
-        return (countSeconds % 3600) / 60
-    }
-    private var currentSeconds: Int {
-        return (countSeconds % 60)
-    }
-    //MARK: OVERTIME TIME PROPERTIES - PRIVATE
-    private var countOvertimeSeconds: Int  = 0
-    private var overtimeHours: Int {
-        return countOvertimeSeconds/3600
-    }
-    private var overtimeMinutes: Int {
-        return (countOvertimeSeconds % 3600) / 60
-    }
-    private var overtimeSeconds: Int {
-        return (countOvertimeSeconds % 60)
-    }
-    //MARK: BACKGROUND TIMER HANDLING PROPERTIES - PRIVATE
     private var appDidEnterBackgroundDate: Date?
+    private var subscriptions = Set<AnyCancellable>()
+    //TIMER
+    private var timerProvider: Timer.Type = Timer.self
+    private var workTimerService: TimerService
+    
+    @Published var state: TimerService.TimerServiceState = .notStarted
+    var timerDisplayValue: TimeInterval {
+        return workTimerService.counter
+    }
+    var normalProgress: CGFloat {
+        return workTimerService.progress
+    }
     
     init(dataManager: DataManager, settingsStore: SettingsStore, payManager: PayManager ,timerProvider: Timer.Type) {
         self.dataManager = dataManager
         self.settingsStore = settingsStore
         self.timerProvider = timerProvider
         self.payManager = payManager
+        // register new timer service
+        self.workTimerService = .init(
+            timerProvider: timerProvider,
+            timerLimit: TimeInterval(settingsStore.workTimeInSeconds)
+        )
         super.init()
-        countSeconds = settingsStore.workTimeInSeconds
-        updateTimerStringValue()
         setAppStateObservers()
-        settingsStore.$workTimeInSeconds
-            .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] value in
-                guard let self else { return }
-                if !self.isStarted {
-                    self.countSeconds = value
-                    self.updateTimerStringValue()
-                }
-            })
-            .store(in: &subscriptions)
+        setUpTimerSubscribers()
+    }
+    private func setUpTimerSubscribers() {
+        self.workTimerService.objectWillChange.sink { _ in
+            self.objectWillChange.send()
+        }.store(in: &subscriptions)
         
+        // this is a subscriber for saving when timer is set to finished
+        self.workTimerService.$serviceState.filter { state in
+            return state == .finished
+        }.sink { [weak self] _ in
+            self?.saveEntry()
+        }.store(in: &subscriptions)
     }
 }
+
+//MARK: TIMER INTERFACE
+extension HomeViewModel {
+    func startTimerService() {
+        if workTimerService.serviceState == .finished {
+            workTimerService = .init(
+                timerProvider: timerProvider,
+                timerLimit: TimeInterval(settingsStore.workTimeInSeconds)
+            )
+            setUpTimerSubscribers()
+        }
+        if workTimerService.serviceState == .notStarted {
+            startDate = Date()
+        }
+        self.state = .running
+        workTimerService.send(event: .start)
+    }
+    
+    func pauseTimerService() {
+        self.state = .paused
+        workTimerService.send(event: .pause)
+    }
+    
+    func stopTimerService() {
+        self.state = .notStarted
+        workTimerService.send(event: .stop)
+        finishDate = Date()
+    }
+    
+    func resumeFromBackground(_ appDidEnterBackgroundDate: Date) {
+        let timePassedInBackground = DateInterval(start: appDidEnterBackgroundDate, end: Date()).duration
+        workTimerService.send(event: .resumeWith(timePassedInBackground))
+    }
+}
+
 //MARK: HANDLING BACKGROUND TIMER UPDATE FUNC
 extension HomeViewModel {
     
@@ -90,152 +101,44 @@ extension HomeViewModel {
     }
     
     @objc private func appDidEnterBackground() {
-        if isRunning {
+        if workTimerService.serviceState == .running {
             appDidEnterBackgroundDate = Date()
-            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: Double(countSeconds), repeats: false)
+            let timeToTimerFinish: TimeInterval? = {
+                if workTimerService.serviceState == .running {
+                    return workTimerService.remainingTime
+                }
+                return nil
+            }()
+            guard let timeToTimerFinish else { return }
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeToTimerFinish , repeats: false)
             checkForPermissionAndDispatch(withTrigger: trigger)
         }
     }
     
     @objc private func appWillEnterForeground() {
         guard let appDidEnterBackgroundDate else { return }
-        let timeInBackground = Calendar.current.dateComponents([.second], from: appDidEnterBackgroundDate, to: Date())
-        if let secondsInBackground = timeInBackground.second {
-            updateTimer(subtract: secondsInBackground)
-            updateTimerStringValue()
-        } else {
-            print("Failed to retrive seconds spend in background! Timer value is not valid!")
-        }
-        //remove pending notifications
+        resumeFromBackground(appDidEnterBackgroundDate)
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [K.Notification.identifier])
-    }
-    
-}
-
-//MARK: TIMER START & STOP FUNCTIONS
-extension HomeViewModel {
-
-    func startTimer()  {
-        
-        startDate = Date()
-        
-        countSeconds = settingsStore.workTimeInSeconds
-        countOvertimeSeconds = 0
-        
-        progress = 0
-        overtimeProgress = 0
-        // this still does not work in the background
-        timer = timerProvider.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
-            guard let self else { return }
-            self.updateTimer()
-        })
-        
-        isStarted = true
-        isRunning = true
-    }
-    
-    func stopTimer() {
-        if let timer = timer {
-            timer.invalidate()
-        }
-        isStarted = false
-        isRunning = false
-        finishDate = Date()
-        saveEntry()
-    }
-}
-   
-//MARK: TIMER UPDATE FUNCTIONS
-extension HomeViewModel {
-    
-    /**
-     Updates the timer countdown value
-     - Parameter subtrahend: The value to be substracted from the countdown (default is 1)
-     */
-    func updateTimer(subtract subtrahend: Int = 1) {
-        if isStarted && isRunning {
-            let timerTotalSeconds = settingsStore.workTimeInSeconds
-            //This is the situation when the timer is still in current state after the update, including 0
-            if countSeconds >= subtrahend {
-                countSeconds -= subtrahend
-                withAnimation(.easeInOut) {
-                    progress = 1 - CGFloat(countSeconds) / CGFloat(timerTotalSeconds)
-                }
-                updateTimerStringValue()
-                return
-            }
-            //this is the situation when timer value moves it into overtime
-            if countSeconds < subtrahend {
-                if progressAfterFinish {
-                    countSeconds = 0
-                    countOvertimeSeconds += subtrahend - countSeconds
-                    //update the progress rings
-                    withAnimation(.easeInOut) {
-                        progress = 1 - CGFloat(countSeconds) / CGFloat(timerTotalSeconds)
-                        overtimeProgress = CGFloat(countOvertimeSeconds) / CGFloat(settingsStore.maximumOvertimeAllowedInSeconds)
-                    }
-                    updateTimerStringValue()
-                } else {
-                    countSeconds = 0
-                    withAnimation(.easeInOut) {
-                        progress = 1 - CGFloat(countSeconds) / CGFloat(timerTotalSeconds)
-                    }
-                    updateTimerStringValue()
-                    stopTimer()
-                }
-            }
-        }
-    }
-    
-    /// Updates the timer string value with current time components if the countSeconds > 0 and with current overtime components if countSeconds = 0.
-    func updateTimerStringValue() {
-        if countSeconds > 0 {
-            
-            let hoursComponent: String = currentHours < 10 ? "0\(currentHours)" : "\(currentHours)"
-            let minutesComponent: String = currentMinutes < 10 ? "0\(currentMinutes)" : "\(currentMinutes)"
-            let secondsComponent: String = currentSeconds < 10 ? "0\(currentSeconds)" : "\(currentSeconds)"
-            
-            if currentHours > 0 {
-                timerStringValue = "\(hoursComponent) : \(minutesComponent)"
-            } else {
-                timerStringValue = "\(minutesComponent) : \(secondsComponent)"
-            }
-        } else if countOvertimeSeconds == 0 && countSeconds == 0 {
-            timerStringValue = "00:00"
-        } else {
-            
-            let hoursComponent: String = overtimeHours < 10 ? "0\(overtimeHours)" : "\(overtimeHours)"
-            let minutesComponent: String = overtimeMinutes < 10 ? "0\(overtimeMinutes)" : "\(overtimeMinutes)"
-            let secondsComponent: String = overtimeSeconds < 10 ? "0\(overtimeSeconds)" : "\(overtimeSeconds)"
-            
-            if overtimeHours > 0 {
-                timerStringValue = "\(hoursComponent) : \(minutesComponent)"
-            } else {
-                timerStringValue = "\(minutesComponent) : \(secondsComponent)"
-            }
-        }
     }
     
 }
 
 //MARK: DATA OPERATIONS
 extension HomeViewModel {
-    
     func saveEntry() {
         guard let startDate = startDate, let finishDate = finishDate else { return }
-        
-        let workTimeInSeconds = settingsStore.workTimeInSeconds - countSeconds
-        let overTimeInSeconds = countOvertimeSeconds
         let calculatedNetPay: Double? = {
             settingsStore.isCalculatingNetPay ? payManager.calculateNetPay(gross: Double(settingsStore.grossPayPerMonth)) : nil
         }()
         let entryToSave = Entry(startDate: startDate,
                                 finishDate: finishDate,
-                                workTimeInSec: workTimeInSeconds,
-                                overTimeInSec: overTimeInSeconds,
+                                workTimeInSec: Int(workTimerService.counter),
+                                overTimeInSec: 0,
                                 maximumOvertimeAllowedInSeconds: settingsStore.maximumOvertimeAllowedInSeconds,
                                 standardWorktimeInSeconds: settingsStore.workTimeInSeconds,
-                                grossPayPerMonth: settingsStore.grossPayPerMonth, calculatedNetPay: calculatedNetPay)
+                                grossPayPerMonth: settingsStore.grossPayPerMonth, 
+                                calculatedNetPay: calculatedNetPay
+        )
         dataManager.updateAndSave(entry: entryToSave)
     }
 }

--- a/ClockInTests/EditSheetViewModelTests.swift
+++ b/ClockInTests/EditSheetViewModelTests.swift
@@ -32,7 +32,11 @@ final class EditSheetViewModelTests: XCTestCase {
         SettingsStore.setTestUserDefaults()
         let settingStore = SettingsStore()
         
-        sut = .init(dataManager: .testing, settingsStore: settingStore, entry: entry, calendar: .current)
+        sut = .init(dataManager: .testing,
+                    settingsStore: settingStore,
+                    payService: PayManager(dataManager: .testing, settingsStore: settingStore),
+                    calendar: .current,
+                    entry: entry)
     }
 
     override func tearDown() {

--- a/ClockInTests/HomeViewModelTests.swift
+++ b/ClockInTests/HomeViewModelTests.swift
@@ -96,9 +96,9 @@ final class HomeViewModelModelTests: XCTestCase {
         let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground)
         let expectedNormalProgressValue = CGFloat(numberOfSecondsPassedInBackground) / CGFloat(workTimerLimit)
         let expectedOvertimeProgressValue = CGFloat(0)
-        var enterBackgroundDate: Date = {
+        var enterBackgroundDate: Date {
             Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
-        }()
+        }
         setUpWithOneTimer()
         //When
         sut.startTimerService()
@@ -115,9 +115,9 @@ final class HomeViewModelModelTests: XCTestCase {
         let expectedDisplayValue = TimeInterval(0)
         let expectedNormalProgressValue = CGFloat(0)
         let expectedOvertimeProgressValue = CGFloat(0)
-        var enterBackgroundDate: Date = {
+        var enterBackgroundDate: Date {
             Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
-        }()
+        }
         setUpWithOneTimer()
         //When
         sut.resumeFromBackground(enterBackgroundDate)
@@ -230,9 +230,9 @@ final class HomeViewModelModelTests: XCTestCase {
         let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground)
         let expectedNormalProgressValue = CGFloat(1)
         let expectedOvertimeProgressValue = CGFloat(numberOfSecondsPassedInBackground) / CGFloat(overtimeTimerLimit)
-        var enterBackgroundDate: Date = {
+        var enterBackgroundDate: Date {
             Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
-        }()
+        }
         setUpWithTwoTimers()
         //When
         sut.startTimerService()
@@ -250,9 +250,9 @@ final class HomeViewModelModelTests: XCTestCase {
         let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground - workTimerLimit)
         let expectedNormalProgressValue = CGFloat(1)
         let expectedOvertimeProgressValue = CGFloat(numberOfSecondsPassedInBackground - workTimerLimit) / CGFloat(overtimeTimerLimit)
-        var enterBackgroundDate: Date = {
+        var enterBackgroundDate: Date {
             Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
-        }()
+        }
         setUpWithTwoTimers()
         //When
         sut.startTimerService()

--- a/ClockInTests/HomeViewModelTests.swift
+++ b/ClockInTests/HomeViewModelTests.swift
@@ -12,11 +12,13 @@ final class HomeViewModelModelTests: XCTestCase {
     
     var sut: HomeViewModel!
     var settingsStore: SettingsStore!
+    var workTimerLimit: Int = 100
     
     override func setUp() {
         super.setUp()
         SettingsStore.setTestUserDefaults()
         self.settingsStore = SettingsStore()
+        DataManager.testing.deleteAll()
         sut = .init(HomeViewModel(dataManager: DataManager.testing,
                                   settingsStore: settingsStore,
                                   payManager: PayManager(dataManager: DataManager.testing, settingsStore: settingsStore),
@@ -27,5 +29,128 @@ final class HomeViewModelModelTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         sut = nil
+    }
+    
+    func test_startTimerService_when_noOvertime_firstRun() {
+        //Given
+        setUpWithOneTimer()
+        //When
+        sut.startTimerService()
+        //Then
+        XCTAssertEqual(sut.state, .running, "State should be equal to `running`")
+    }
+
+    func test_timerProperties_updateWhenRunning() {
+        //Given
+        let numberOfFires = 10
+        let expectedNormalProgressValue = CGFloat(numberOfFires) / CGFloat(workTimerLimit)
+        let expectedOvertimeProgressValue = CGFloat(0)
+        setUpWithOneTimer()
+        //When
+        sut.startTimerService()
+        fireTimer(10)
+        //Then
+        XCTAssertEqual(sut.timerDisplayValue, TimeInterval(numberOfFires), "Timer display value should be equal to 10")
+        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+
+    func test_timerProperties_notUpdating_whenPaused() {
+        //Given
+        setUpWithOneTimer()
+        //When
+        sut.startTimerService()
+        fireTimer(10)
+        sut.pauseTimerService()
+        fireTimer(10)
+        //Then
+        XCTAssertEqual(sut.timerDisplayValue, TimeInterval(integerLiteral: 10), "Timer display value should be equal to 10")
+        XCTAssertEqual(sut.normalProgress, CGFloat(0.1), "Normal progress should be equal to 0.1")
+        XCTAssertEqual(sut.overtimeProgress, CGFloat(0), "Overtime progress should be equal to 0")
+    }
+
+    func test_resumeTimerService_whenPaused() {
+        //Given
+        let numberOfFires = 10
+        let expectedNormalProgressValue = CGFloat(2 * numberOfFires) / CGFloat(workTimerLimit)
+        let expectedOvertimeProgressValue = CGFloat(0)
+        setUpWithOneTimer()
+        //When
+        sut.startTimerService()
+        fireTimer(10)
+        sut.pauseTimerService()
+        sut.resumeTimerService()
+        fireTimer(10)
+        //Then
+        XCTAssertEqual(sut.timerDisplayValue, TimeInterval(2 * numberOfFires), "Timer display value should be equal to \(2 * numberOfFires)")
+        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+
+    func test_resumeFromBackground_when_timerServiceWasStarted() {
+        //Given
+        let numberOfSecondsPassedInBackground = 10
+        let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground)
+        let expectedNormalProgressValue = CGFloat(numberOfSecondsPassedInBackground) / CGFloat(workTimerLimit)
+        let expectedOvertimeProgressValue = CGFloat(0)
+        var enterBackgroundDate: Date = {
+            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
+        }()
+        setUpWithOneTimer()
+        //When
+        sut.startTimerService()
+        sut.resumeFromBackground(enterBackgroundDate)
+        //Then
+        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue, accuracy: 0.01, "Timer display value should be equal to \(expectedDisplayValue)")
+        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, accuracy: 0.01, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
+    func test_resumeFromBackground_when_timerServiceWasNotStarted() {
+        //Given
+        let numberOfSecondsPassedInBackground = 10
+        let expectedDisplayValue = TimeInterval(0)
+        let expectedNormalProgressValue = CGFloat(0)
+        let expectedOvertimeProgressValue = CGFloat(0)
+        var enterBackgroundDate: Date = {
+            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
+        }()
+        setUpWithOneTimer()
+        //When
+        sut.resumeFromBackground(enterBackgroundDate)
+        //Then
+        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue, accuracy: 0.01, "Timer display value should be equal to \(numberOfSecondsPassedInBackground)")
+        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, accuracy: 0.01, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+
+    func test_stopTimerService_stopsServiceAndSavesEntry() {
+        //Given
+        let numberOfExistingEntries = DataManager.testing.entryArray.count
+        let numberOfFires = 10
+        setUpWithOneTimer()
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        sut.stopTimerService()
+        //Then
+        XCTAssertEqual(sut.state, .notStarted, "Service state should be not started")
+        XCTAssertEqual(DataManager.testing.entryArray.count, numberOfExistingEntries + 1, "Additional entry should be saved")
+    }
+    
+    private func setUpWithOneTimer() {
+        settingsStore.isLoggingOvertime = false
+        settingsStore.workTimeInSeconds = workTimerLimit
+        sut = .init(HomeViewModel(dataManager: DataManager.testing,
+                                  settingsStore: settingsStore,
+                                  payManager: PayManager(dataManager: DataManager.testing, settingsStore: settingsStore),
+                                  timerProvider: MockTimer.self)
+        )
+    }
+    
+    private func fireTimer(_ numberOfFires: Int) {
+        for _ in 0...numberOfFires - 1 {
+            MockTimer.currentTimer.fire()
+        }
     }
 }

--- a/ClockInTests/HomeViewModelTests.swift
+++ b/ClockInTests/HomeViewModelTests.swift
@@ -7,12 +7,15 @@
 
 import XCTest
 @testable import ClockIn
+//TODO: Add test for starting service when first service finished
+//TODO: write a test for resume from background when time in background exeeds timer limit
 
 final class HomeViewModelModelTests: XCTestCase {
     
     var sut: HomeViewModel!
     var settingsStore: SettingsStore!
     var workTimerLimit: Int = 100
+    var overtimeTimerLimit: Int = 100
     
     override func setUp() {
         super.setUp()
@@ -40,7 +43,7 @@ final class HomeViewModelModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .running, "State should be equal to `running`")
     }
 
-    func test_timerProperties_updateWhenRunning() {
+    func test_timerProperties_updateWhenRunning_noOvertime() {
         //Given
         let numberOfFires = 10
         let expectedNormalProgressValue = CGFloat(numberOfFires) / CGFloat(workTimerLimit)
@@ -55,7 +58,7 @@ final class HomeViewModelModelTests: XCTestCase {
         XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
     }
 
-    func test_timerProperties_notUpdating_whenPaused() {
+    func test_timerProperties_notUpdating_whenPaused_noOvertime() {
         //Given
         setUpWithOneTimer()
         //When
@@ -69,7 +72,7 @@ final class HomeViewModelModelTests: XCTestCase {
         XCTAssertEqual(sut.overtimeProgress, CGFloat(0), "Overtime progress should be equal to 0")
     }
 
-    func test_resumeTimerService_whenPaused() {
+    func test_resumeTimerService_whenPaused_noOvertime() {
         //Given
         let numberOfFires = 10
         let expectedNormalProgressValue = CGFloat(2 * numberOfFires) / CGFloat(workTimerLimit)
@@ -86,8 +89,8 @@ final class HomeViewModelModelTests: XCTestCase {
         XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
         XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
     }
-
-    func test_resumeFromBackground_when_timerServiceWasStarted() {
+    
+    func test_resumeFromBackground_when_timerServiceWasStarted_noOvertime() {
         //Given
         let numberOfSecondsPassedInBackground = 10
         let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground)
@@ -106,7 +109,7 @@ final class HomeViewModelModelTests: XCTestCase {
         XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
     }
     
-    func test_resumeFromBackground_when_timerServiceWasNotStarted() {
+    func test_resumeFromBackground_when_timerServiceWasNotStarted_noOvertime() {
         //Given
         let numberOfSecondsPassedInBackground = 10
         let expectedDisplayValue = TimeInterval(0)
@@ -124,7 +127,7 @@ final class HomeViewModelModelTests: XCTestCase {
         XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
     }
 
-    func test_stopTimerService_stopsServiceAndSavesEntry() {
+    func test_stopTimerService_stopsServiceAndSavesEntry_noOvertime() {
         //Given
         let numberOfExistingEntries = DataManager.testing.entryArray.count
         let numberOfFires = 10
@@ -138,6 +141,147 @@ final class HomeViewModelModelTests: XCTestCase {
         XCTAssertEqual(DataManager.testing.entryArray.count, numberOfExistingEntries + 1, "Additional entry should be saved")
     }
     
+    func test_startSecondTimer_whenFirstIsFinished() {
+        //Given
+        let numberOfFires = workTimerLimit + 1
+        let expectedNormalProgress = CGFloat(1)
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        //Then
+        XCTAssertEqual(sut.normalProgress, expectedNormalProgress, "Normal progress should be equal to 0")
+        XCTAssert(sut.overtimeProgress > 0, "Overtime progress should be bigger than 0")
+        XCTAssertEqual(sut.state, .running, "SUT state should be running")
+    }
+    
+    func test_displayedValue_whenFirstTimerFinished_whenSecondTimerStarts() {
+        //Given
+        let expectedDisplayValueFromFirstTimer: CGFloat = 100
+        let expectedDisplayValueFromSecondTimer: CGFloat = 1
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(workTimerLimit)
+        //Then
+        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValueFromFirstTimer)
+        //When
+        fireTimer(1)
+        //Then
+        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValueFromSecondTimer)
+    }
+    
+    func test_timerPropertiesUpdate_whenSecondTimerIsRunning() {
+        //Given
+        let numberOfFires = workTimerLimit + 10
+        let expectedDisplayValue = TimeInterval(10)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(numberOfFires - workTimerLimit) / CGFloat(overtimeTimerLimit)
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        //Then
+        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue, "Timer display value should be equal to 10")
+        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
+    func test_timerProperties_notUpdating_whenPaused_withOvertime() {
+        //Given
+        let numberOfFires = workTimerLimit + 10
+        let expectedDisplayValue = TimeInterval(10)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(numberOfFires - workTimerLimit) / CGFloat(overtimeTimerLimit)
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        sut.pauseTimerService()
+        fireTimer(10)
+        //Then
+        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue, "Timer display value should be equal to 10")
+        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
+    func test_resumeTimerService_whenPaused_withOvertime() {
+        //Given
+        let numberOfFires = workTimerLimit + 10
+        let expectedDisplayValue = TimeInterval(20)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(20) / CGFloat(overtimeTimerLimit)
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        sut.pauseTimerService()
+        sut.resumeTimerService()
+        fireTimer(10)
+        //Then
+        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue , "Timer display value should be equal to \(expectedDisplayValue)")
+        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
+    func test_resumeFromBackground_whenSecondTimerWasStarted() {
+        //Given
+        let numberOfSecondsPassedInBackground = 11
+        let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(numberOfSecondsPassedInBackground) / CGFloat(overtimeTimerLimit)
+        var enterBackgroundDate: Date = {
+            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
+        }()
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(workTimerLimit)
+        sut.resumeFromBackground(enterBackgroundDate)
+        //Then
+        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue, accuracy: 0.01, "Timer display value should be equal to \(expectedDisplayValue)")
+        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
+    func test_resumeFromBackground_whenTimeInBackgroundExceedsFirstTimeLimit() {
+        //Given
+        let numberOfSecondsPassedInBackground = workTimerLimit + 10
+        let expectedDisplayValue = TimeInterval(numberOfSecondsPassedInBackground - workTimerLimit)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(numberOfSecondsPassedInBackground - workTimerLimit) / CGFloat(overtimeTimerLimit)
+        var enterBackgroundDate: Date = {
+            Calendar.current.date(byAdding: .second, value: -numberOfSecondsPassedInBackground, to: Date())!
+        }()
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        
+        sut.resumeFromBackground(enterBackgroundDate)
+        //Then
+        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue, accuracy: 0.01, "Timer display value should be equal to \(expectedDisplayValue)")
+        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+
+    func test_stopTimerService_stopsSecondTimerAndSavesEntry() {
+        let numberOfFires = workTimerLimit + overtimeTimerLimit
+        let expectedDisplayValue = TimeInterval(overtimeTimerLimit)
+        let expectedNormalProgressValue = CGFloat(1)
+        let expectedOvertimeProgressValue = CGFloat(1)
+        let expectedNumberOfEntries = DataManager.testing.entryArray.count + 1
+        setUpWithTwoTimers()
+        //When
+        sut.startTimerService()
+        fireTimer(numberOfFires)
+        sut.stopTimerService()
+        //Then
+        XCTAssertEqual(DataManager.testing.entryArray.count, expectedNumberOfEntries, "Number of entries should be equal to \(expectedNumberOfEntries)")
+        XCTAssertEqual(sut.timerDisplayValue, expectedDisplayValue, accuracy: 0.01, "Timer display value should be equal to \(expectedDisplayValue)")
+        XCTAssertEqual(sut.normalProgress, expectedNormalProgressValue, "Normal progress should be equal to \(expectedNormalProgressValue)")
+        XCTAssertEqual(sut.overtimeProgress, expectedOvertimeProgressValue, accuracy: 0.01, "Overtime progress should be equal to \(expectedOvertimeProgressValue)")
+    }
+    
     private func setUpWithOneTimer() {
         settingsStore.isLoggingOvertime = false
         settingsStore.workTimeInSeconds = workTimerLimit
@@ -146,6 +290,17 @@ final class HomeViewModelModelTests: XCTestCase {
                                   payManager: PayManager(dataManager: DataManager.testing, settingsStore: settingsStore),
                                   timerProvider: MockTimer.self)
         )
+    }
+    
+    private func setUpWithTwoTimers() {
+        settingsStore.isLoggingOvertime = true
+        settingsStore.workTimeInSeconds = workTimerLimit
+        settingsStore.maximumOvertimeAllowedInSeconds = overtimeTimerLimit
+        sut = .init(dataManager: DataManager.testing,
+                    settingsStore: settingsStore,
+                    payManager: PayManager(dataManager: .testing, 
+                                           settingsStore: settingsStore),
+                    timerProvider: MockTimer.self)
     }
     
     private func fireTimer(_ numberOfFires: Int) {

--- a/ClockInTests/HomeViewModelTests.swift
+++ b/ClockInTests/HomeViewModelTests.swift
@@ -28,35 +28,4 @@ final class HomeViewModelModelTests: XCTestCase {
         super.tearDown()
         sut = nil
     }
-
-    func testUpdateTimer_whenCountSecondsSmallerThanSubtrahend() throws {
-        sut.startTimer()
-        for _ in 0...9 {
-            MockTimer.currentTimer.fire()
-        }
-        let valuePredictedAfterOneFire: CGFloat = 1 - CGFloat(settingsStore.workTimeInSeconds - 10) / CGFloat (settingsStore.workTimeInSeconds)
-        XCTAssertEqual(sut.progress, valuePredictedAfterOneFire, "Timer should fire once")
-    }
-    
-    func testUpdateTimer_whenCountSecondsBiggerThanSubtrahendAndNoOvertimeAllowed() throws {
-        sut.progressAfterFinish = false
-        sut.startTimer()
-        for _ in 0...settingsStore.workTimeInSeconds {
-                MockTimer.currentTimer.fire()
-        }
-        XCTAssertFalse(MockTimer.currentTimer.isValid, "Timer should be invalid")
-        XCTAssertEqual(sut.progress, 1, "Progress should be equal to 1")
-    }
-    
-    func testUpdateTimer_whenCountSecondsBiggerThanSubtrahendAndOvertimeAllowed() throws {
-        sut.progressAfterFinish = true
-        sut.startTimer()
-        for _ in 0...settingsStore.workTimeInSeconds + 9  {
-                MockTimer.currentTimer.fire()
-        }
-        let valuePredicted: CGFloat = CGFloat(10) / CGFloat (settingsStore.maximumOvertimeAllowedInSeconds)
-        XCTAssertTrue(MockTimer.currentTimer.isValid, "Timer should be valid")
-        XCTAssertEqual(sut.progress, 1, "Progress should be equal to 1")
-        XCTAssertEqual(sut.overtimeProgress, valuePredicted, "overtimeProgress should be equal to predicted value")
-    }
 }

--- a/ClockInTests/TimerServiceTests.swift
+++ b/ClockInTests/TimerServiceTests.swift
@@ -30,7 +30,7 @@ final class TimerServiceTests: XCTestCase {
     func testUpdateTimer_firstCounter() {
         // Given
         let numberOfFires = 10
-        let expectedCounterValue: TimeInterval = TimeInterval(timerLimit - numberOfFires)
+        let expectedCounterValue: TimeInterval = TimeInterval(numberOfFires)
         //When
         sut.startTimer()
         for _ in 0...numberOfFires - 1 {
@@ -54,8 +54,8 @@ final class TimerServiceTests: XCTestCase {
     
     func testProgressToFirstLimit() {
         // Given
-        let numberOfFires: Int = timerLimit / 2
-        let expectedProgressValue: CGFloat = 0.5
+        let numberOfFires: Int = timerLimit / 4
+        let expectedProgressValue: CGFloat = 0.25
         //When
         sut.startTimer()
         for _ in 0...numberOfFires - 1 {

--- a/ClockInTests/TimerServiceTests.swift
+++ b/ClockInTests/TimerServiceTests.swift
@@ -24,6 +24,12 @@ final class TimerServiceTests: XCTestCase {
         super.tearDown()
         sut = nil
     }
+    
+    private func fireTimer(_ numberOfFires: Int) {
+        for _ in 0...numberOfFires - 1 {
+            MockTimer.currentTimer.fire()
+        }
+    }
 }
 
 //MARK: TEST STATE CHANGES
@@ -157,16 +163,29 @@ extension TimerServiceTests {
         sut.send(event: .start)
         fireTimer(numberOfFires)
         //Then
-        XCTAssertEqual(sut.progressToFirstLimit, expectedProgressValue, "Value value should be equal to predicted value (\(expectedProgressValue))")
+        XCTAssertEqual(sut.progress, expectedProgressValue, "Progress value should be equal to predicted value (\(expectedProgressValue))")
     }
     
-//    func test_counter_notUpdating_whenPaused() {
-//        
-//    }
+    func test_counter_notUpdating_whenPaused() {
+        //Given
+        let numberOfFires: Int = timerLimit / 4
+        //When
+        sut.send(event: .start)
+        sut.send(event: .pause)
+        fireTimer(numberOfFires)
+        //Then
+        XCTAssertEqual(sut.counter, 0, "Counter value should be 0")
+        XCTAssertEqual(sut.progress, 0, "Progress value should be 0")
+    }
     
-    private func fireTimer(_ numberOfFires: Int) {
-        for _ in 0...numberOfFires - 1 {
-            MockTimer.currentTimer.fire()
-        }
+    func test_counterAndProgress_updated_whenResumeWithValueSent() {
+        //Given
+        let numberOfFires: Int = timerLimit / 4
+        //When
+        sut.send(event: .start)
+        sut.send(event: .pause)
+        sut.send(event: .resumeWith(TimeInterval(numberOfFires)))
+        XCTAssertEqual(sut.counter, TimeInterval(timerLimit / 4), "Counter value should be \(timerLimit/4)")
+        XCTAssertEqual(sut.progress, 0.25, "Progress value should be 0.25")
     }
 }

--- a/ClockInTests/TimerServiceTests.swift
+++ b/ClockInTests/TimerServiceTests.swift
@@ -26,7 +26,7 @@ final class TimerServiceTests: XCTestCase {
         super.tearDown()
         sut = nil
     }
-
+    
     func testUpdateTimer_firstCounter() {
         // Given
         let numberOfFires = 10
@@ -50,5 +50,31 @@ final class TimerServiceTests: XCTestCase {
         }
         //Then
         XCTAssertEqual(expectedSecondCounterValue, sut.secondCounter, "Counter value should be equal to predicted value")
+    }
+    
+    func testProgressToFirstLimit() {
+        // Given
+        let numberOfFires: Int = timerLimit / 2
+        let expectedProgressValue: CGFloat = 0.5
+        //When
+        sut.startTimer()
+        for _ in 0...numberOfFires - 1 {
+            MockTimer.currentTimer.fire()
+        }
+        //Then
+        XCTAssertEqual(sut.progressToFirstLimit, expectedProgressValue, "Value value should be equal to predicted value (\(expectedProgressValue))")
+    }
+    
+    func testProgressToSecondLimit_whenFirstLimitNotReached() {
+        // Given
+        let numberOfFires: Int = timerLimit / 2
+        let expectedProgressValue: CGFloat = 0
+        //When
+        sut.startTimer()
+        for _ in 0...numberOfFires - 1 {
+            MockTimer.currentTimer.fire()
+        }
+        //Then
+        XCTAssertEqual(sut.progressToSecondLimit, expectedProgressValue, "Value value should be equal to predicted value (\(expectedProgressValue))")
     }
 }

--- a/ClockInTests/TimerServiceTests.swift
+++ b/ClockInTests/TimerServiceTests.swift
@@ -1,0 +1,54 @@
+//
+//  TimerServiceTests.swift
+//  ClockInTests
+//
+//  Created by Tomasz Kubiak on 22/12/2023.
+//
+
+import XCTest
+@testable import ClockIn
+
+final class TimerServiceTests: XCTestCase {
+    var sut: TimerService!
+    
+    let timerLimit = 180
+    let timerSecondLimit = 60
+    
+    override func setUp() {
+        super.setUp()
+        sut = .init(timerProvider: MockTimer.self,
+                    timerLimit: TimeInterval(timerLimit),
+                    timerSecondLimit: TimeInterval(timerSecondLimit),
+                    progressAfterLimit: true)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        sut = nil
+    }
+
+    func testUpdateTimer_firstCounter() {
+        // Given
+        let numberOfFires = 10
+        let expectedCounterValue: TimeInterval = TimeInterval(timerLimit - numberOfFires)
+        //When
+        sut.startTimer()
+        for _ in 0...numberOfFires - 1 {
+            MockTimer.currentTimer.fire()
+        }
+        //Then
+        XCTAssertEqual(sut.firstCounter, expectedCounterValue, "Counter value should be equal to predicted value")
+    }
+    
+    func testUpdateTimer_secondCounter() {
+        let numberOfFires = timerLimit + 10
+        let expectedSecondCounterValue = TimeInterval(integerLiteral: 10)
+        //When
+        sut.startTimer()
+        for _ in 0...numberOfFires - 1 {
+            MockTimer.currentTimer.fire()
+        }
+        //Then
+        XCTAssertEqual(expectedSecondCounterValue, sut.secondCounter, "Counter value should be equal to predicted value")
+    }
+}

--- a/ClockInUITests/ScreenHelpers/HomeViewScreen.swift
+++ b/ClockInUITests/ScreenHelpers/HomeViewScreen.swift
@@ -15,7 +15,14 @@ class HomeViewScreen {
     }
     
     var timerStartPauseButton: XCUIElement {
-        app.buttons[ScreenIdentifier.HomeView.startPauseButton.rawValue]
+        app.buttons[ScreenIdentifier.HomeView.startButton.rawValue]
+    }
+    
+    var timerPauseButton: XCUIElement {
+        app.buttons[ScreenIdentifier.HomeView.pauseButton.rawValue]
+    }
+    var timerResumeButton: XCUIElement {
+        app.buttons[ScreenIdentifier.HomeView.resumeButton.rawValue]
     }
     
     var timerFinishButton: XCUIElement {


### PR DESCRIPTION
In this PR I encapsulated logic for operating timers from home view model to a separate service. Service was split into singular timer, and two timers were created in the view model. Additional unit tests were written for both  TimerService and HomeViewModel. HomeView was adjusted to work with new view model. 