### PR TITLE
24 edit sheet screen not updating indicator on settings override

### DIFF
--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -245,7 +245,7 @@ extension EditSheetView {
                 .foregroundColor(.black)
             }
             divider
-            Toggle(isOn: .constant(true)) {
+            Toggle(isOn: $viewModel.calculateNetPay) {
                 Text(calculateNetPayText)
              
             }

--- a/ClockIn/View/EditSheetView.swift
+++ b/ClockIn/View/EditSheetView.swift
@@ -120,7 +120,7 @@ extension EditSheetView {
     var diffDayDateControls: some View {
         Group {
             CustomDatePickerContainer(labelText: startDateText) {
-                DatePicker(startDateText, selection: $viewModel.startDate)
+                DatePicker(startDateText, selection: $viewModel.startDate, in: PartialRangeThrough(viewModel.finishDate))
                     .labelsHidden()
                     .accessibilityIdentifier(Identifier.DatePicker.startDate.rawValue)
             } trailing: {
@@ -129,8 +129,8 @@ extension EditSheetView {
             .frame(height: 50)
             .padding(.top)
             
-            CustomDatePickerContainer(labelText: startDateText) {
-                DatePicker(finishDateText, selection: $viewModel.finishDate)
+            CustomDatePickerContainer(labelText: finishDateText) {
+                DatePicker(finishDateText, selection: $viewModel.finishDate, in: PartialRangeFrom(viewModel.startDate))
                     .labelsHidden()
                     .accessibilityIdentifier(Identifier.DatePicker.finishDate.rawValue)
             } trailing: {

--- a/ClockIn/View/MainView.swift
+++ b/ClockIn/View/MainView.swift
@@ -88,7 +88,7 @@ struct MainView: View {
         case .history:
             makeToolBarItemIcon("plus")
                 .onTapGesture {
-                    selectedEntry = Entry()
+                    selectedEntry = historyViewModel.newEntry()
                 }
         case .statistics:
             EmptyView()

--- a/ClockIn/ViewModel/HistoryViewModel.swift
+++ b/ClockIn/ViewModel/HistoryViewModel.swift
@@ -58,6 +58,18 @@ final class HistoryViewModel: ObservableObject {
         self.groupedEntries = loadInitialEntries()
     }
     
+    ///Return new entry with current date, empty time properties, and default values driven by setting store values
+    func newEntry() -> Entry {
+        return Entry(startDate: Date(),
+                          finishDate: Date(),
+                          workTimeInSec: 0,
+                          overTimeInSec: 0,
+                          maximumOvertimeAllowedInSeconds: settingsStore.maximumOvertimeAllowedInSeconds,
+                          standardWorktimeInSeconds: settingsStore.workTimeInSeconds,
+                          grossPayPerMonth: settingsStore.grossPayPerMonth,
+                          calculatedNetPay: nil)
+    }
+    
     func deleteEntry(entry: Entry) {
         dataManager.delete(entry: entry)
     }


### PR DESCRIPTION
This PR brings following fixes to entry editing sheet:
- Newly created entry is now populated with values from settings store (such as maximum overtime, standard work time, pay etc)
- Adjusting standard worktime and maximum overtime in overtime settings affects value shown below indicator
- View now adjusts to show single or double date based on if standard worktime is smaller than time till new day starts, and if date is adjusted to be the same day it will switch to show single 
- Toggle is now properly connected to entry properties 
- In double date state pickers are now constrained range
- Added documentation to vm methods