### PR TITLE
Fix controls not reflecting status of the timer in HomeView

### DIFF
--- a/PunchPad/Features/Home/View/HomeView.swift
+++ b/PunchPad/Features/Home/View/HomeView.swift
@@ -124,7 +124,7 @@ private extension HomeView {
         Button {
             viewModel.pauseTimerService()
         } label: {
-            makeLargeButtonLabel(systemName: playIconName)
+            makeLargeButtonLabel(systemName: pauseIconName)
         }
         .buttonStyle(CircleButton())
         .accessibilityIdentifier(Identifier.pauseButton.rawValue)


### PR DESCRIPTION
Issue was traced to a typo in button system image.
Solved by replacing play symbol with pause symbol in pause button.