### PR TITLE
Remove color scheme from settings

### DIFF
--- a/Domains/Package.swift
+++ b/Domains/Package.swift
@@ -112,6 +112,7 @@ let package = Package(
                     .product(name: "TimerService", package: "Services"),
                     .product(name: "PayService", package: "Services"),
                     .product(name: "SettingsService", package: "Services"),
+                    .product(name: "UIComponents", package: "Core")
                 ]
                ),
         .testTarget(name: "HomeTests",

--- a/Services/Package.swift
+++ b/Services/Package.swift
@@ -224,10 +224,7 @@ let package = Package(
                 .product(
                     name: "DomainModels",
                     package: "Core"
-                ),
-                .product(
-                    name: "UIComponents",
-                    package: "Core")
+                )
             ]
         ),
         .target(

--- a/Services/Sources/SettingsService/SettingsService+Logger.swift
+++ b/Services/Sources/SettingsService/SettingsService+Logger.swift
@@ -1,0 +1,4 @@
+import DomainModels
+import OSLog
+
+let logger = Logger.settingsStore

--- a/Services/Sources/SettingsService/SettingsStore+Subscribers.swift
+++ b/Services/Sources/SettingsService/SettingsStore+Subscribers.swift
@@ -1,0 +1,44 @@
+import Combine
+import DomainModels
+
+extension SettingsStore {
+    var boolPublishersWithKeys: [SettingKey: Published<Bool>.Publisher] {
+        [
+            .isRunFirstTime: $isRunFirstTime,
+            .isLoggingOvertime: $isLoggingOvertime,
+            .isCalculatingNetPay: $isCalculatingNetPay,
+            .isSendingNotifications: $isSendingNotification
+        ]
+    }
+    var intPublishersWithKeys: [SettingKey: Published<Int>.Publisher] {
+        [
+            .maximumOvertimeAllowedInSeconds: $maximumOvertimeAllowedInSeconds,
+            .workTimeInSeconds: $workTimeInSeconds,
+            .grossPayPerMonth: $grossPayPerMonth
+        ]
+    }
+
+    func setUpSubscribersSavingToUserDefaults() {
+        logger.debug("setUpSubscribers called")
+        
+        boolPublishersWithKeys
+            .forEach { key, publisher in
+                publisher
+                    .dropFirst()
+                    .removeDuplicates()
+                    .sink { [weak self] value in
+                        self?.updateSetting(setting: key, value: value)
+                    }.store(in: &subscriptions)
+        }
+        
+        intPublishersWithKeys
+            .forEach { key, publisher in
+                publisher
+                    .dropFirst()
+                    .removeDuplicates()
+                    .sink { [weak self] value in
+                        self?.updateSetting(setting: key, value: value)
+                    }.store(in: &subscriptions)
+        }
+    }
+}

--- a/Services/Sources/SettingsService/SettingsStore+TestDefaultsSetting.swift
+++ b/Services/Sources/SettingsService/SettingsStore+TestDefaultsSetting.swift
@@ -1,0 +1,24 @@
+import DomainModels
+import Foundation
+import SettingsServiceInterfaces
+
+extension SettingsStore: TestDefaultsSetting {
+    public static func clearUserDefaults() {
+        logger.debug("clearUserDefaults called")
+        for key in SettingKey.allCases {
+            UserDefaults.standard.removeObject(forKey: key.rawValue)
+        }
+    }
+    
+    public static func setTestUserDefaults() {
+        logger.debug("setTestUserDefaults called")
+        let defaults = UserDefaults.standard
+        defaults.set(false, forKey: SettingKey.isRunFirstTime.rawValue)
+        defaults.set(true, forKey: SettingKey.isLoggingOvertime.rawValue)
+        defaults.set(true, forKey: SettingKey.isCalculatingNetPay.rawValue)
+        defaults.set(false, forKey: SettingKey.isSendingNotifications.rawValue)
+        defaults.set(28800, forKey: SettingKey.workTimeInSeconds.rawValue)
+        defaults.set(14400, forKey: SettingKey.maximumOvertimeAllowedInSeconds.rawValue)
+        defaults.set(10000, forKey: SettingKey.grossPayPerMonth.rawValue)
+    }
+}

--- a/Services/Sources/SettingsService/SettingsStore+UserDefaults.swift
+++ b/Services/Sources/SettingsService/SettingsStore+UserDefaults.swift
@@ -1,0 +1,28 @@
+import DomainModels
+import Foundation
+
+extension SettingsStore {
+    func updateSetting<T>(setting: SettingKey, value: T) {
+        logger.debug("updateSetting called for key: \(setting.rawValue)")
+        defaults.set(value, forKey: setting.rawValue)
+    }
+    
+    func loadValuesFromDefaults() {
+        isLoggingOvertime = defaults.bool(for: .isLoggingOvertime)
+        isCalculatingNetPay = defaults.bool(for: .isCalculatingNetPay)
+        isSendingNotification = defaults.bool(for:.isSendingNotifications)
+        maximumOvertimeAllowedInSeconds = defaults.integer(for: .maximumOvertimeAllowedInSeconds)
+        workTimeInSeconds = defaults.integer(for: .workTimeInSeconds)
+        grossPayPerMonth = defaults.integer(for: .grossPayPerMonth)
+    }
+}
+
+fileprivate extension UserDefaults {
+    func bool(for key: SettingKey) -> Bool {
+        self.bool(forKey: key.rawValue)
+    }
+    
+    func integer(for key: SettingKey) -> Int {
+        self.integer(forKey: key.rawValue)
+    }
+}

--- a/Services/Sources/SettingsService/SettingsStore.swift
+++ b/Services/Sources/SettingsService/SettingsStore.swift
@@ -11,7 +11,6 @@ import OSLog
 import SwiftUI
 import SettingsServiceInterfaces
 import FoundationExtensions
-import UIComponents
 
 public final class SettingsStore: ObservableObject, SettingsStoring, TestDefaultsSetting {
     public var isRunFirstTimePublisher: Published<Bool>.Publisher { $isRunFirstTime }
@@ -29,7 +28,6 @@ public final class SettingsStore: ObservableObject, SettingsStoring, TestDefault
     @Published public var maximumOvertimeAllowedInSeconds: Int
     @Published public var workTimeInSeconds: Int
     @Published public var grossPayPerMonth: Int
-    @Published public var savedColorScheme: ColorScheme?
     
     private var subscriptions = Set<AnyCancellable>()
     private let defaults = UserDefaults.standard
@@ -50,9 +48,6 @@ public final class SettingsStore: ObservableObject, SettingsStoring, TestDefault
         self.workTimeInSeconds = defaults.integer(forKey: SettingKey.workTimeInSeconds.rawValue)
         self.grossPayPerMonth = defaults.integer(
             forKey: SettingKey.grossPayPerMonth.rawValue
-        )
-        self.savedColorScheme = ColorScheme.fromStringValue(
-            defaults.string(forKey: SettingKey.savedColorScheme.rawValue)
         )
         self.setUpSubscribersSavingToUserDefaults()
     }
@@ -79,14 +74,6 @@ public final class SettingsStore: ObservableObject, SettingsStoring, TestDefault
                         self?.updateSetting(setting: key, value: value)
                     }.store(in: &subscriptions)
         }
-
-        $savedColorScheme
-            .dropFirst()
-            .removeDuplicates()
-            .sink { [weak self] value  in
-                guard let self else { return }
-                self.updateSetting(setting: .savedColorScheme, value: value)
-            }.store(in: &subscriptions)
     }
     
     public func clearStore() {
@@ -105,7 +92,6 @@ public final class SettingsStore: ObservableObject, SettingsStoring, TestDefault
         maximumOvertimeAllowedInSeconds = defaults.integer(forKey: SettingKey.maximumOvertimeAllowedInSeconds.rawValue)
         workTimeInSeconds = defaults.integer(forKey: SettingKey.workTimeInSeconds.rawValue)
         grossPayPerMonth = defaults.integer(forKey: SettingKey.grossPayPerMonth.rawValue)
-        savedColorScheme = ColorScheme.fromStringValue(defaults.string(forKey: SettingKey.savedColorScheme.rawValue))
         setUpSubscribersSavingToUserDefaults()
     }
     
@@ -126,7 +112,6 @@ public final class SettingsStore: ObservableObject, SettingsStoring, TestDefault
         defaults.set(28800, forKey: SettingKey.workTimeInSeconds.rawValue)
         defaults.set(14400, forKey: SettingKey.maximumOvertimeAllowedInSeconds.rawValue)
         defaults.set(10000, forKey: SettingKey.grossPayPerMonth.rawValue)
-        defaults.set(nil as ColorScheme?, forKey: SettingKey.savedColorScheme.rawValue)
     }
     
     private func updateSetting<T>(setting: SettingKey, value: T) {

--- a/Services/Sources/SettingsService/SettingsStore.swift
+++ b/Services/Sources/SettingsService/SettingsStore.swift
@@ -7,12 +7,11 @@
 
 import Combine
 import DomainModels
-import OSLog
-import SwiftUI
-import SettingsServiceInterfaces
+import Foundation
 import FoundationExtensions
+import SettingsServiceInterfaces
 
-public final class SettingsStore: ObservableObject, SettingsStoring, TestDefaultsSetting {
+public final class SettingsStore: ObservableObject, SettingsStoring {
     public var isRunFirstTimePublisher: Published<Bool>.Publisher { $isRunFirstTime }
     public var isLoggingOvertimePublisher: Published<Bool>.Publisher { $isLoggingOvertime }
     public var isCalculatingNetPayPublisher: Published<Bool>.Publisher { $isCalculatingNetPay }
@@ -21,60 +20,28 @@ public final class SettingsStore: ObservableObject, SettingsStoring, TestDefault
     public var workTimeInSecondsPublisher: Published<Int>.Publisher { $workTimeInSeconds }
     public var grossPayPerMonthPublisher: Published<Int>.Publisher { $grossPayPerMonth }
 
-    @Published public var isRunFirstTime: Bool
-    @Published public var isLoggingOvertime: Bool
-    @Published public var isCalculatingNetPay: Bool
-    @Published public var isSendingNotification: Bool
-    @Published public var maximumOvertimeAllowedInSeconds: Int
-    @Published public var workTimeInSeconds: Int
-    @Published public var grossPayPerMonth: Int
+    @Published public var isRunFirstTime = false
+    @Published public var isLoggingOvertime = false
+    @Published public var isCalculatingNetPay = false
+    @Published public var isSendingNotification = false
+    @Published public var maximumOvertimeAllowedInSeconds = 0
+    @Published public var workTimeInSeconds = 0
+    @Published public var grossPayPerMonth = 0
     
-    private var subscriptions = Set<AnyCancellable>()
-    private let defaults = UserDefaults.standard
-    private var logger = Logger.settingsStore
+    var subscriptions = Set<AnyCancellable>()
+    let defaults: UserDefaults
 
-    public init() {
+    public init(userDefaults: UserDefaults = .standard) {
+        self.defaults = userDefaults
         if let value = defaults.value(forKey: SettingKey.isRunFirstTime.rawValue) as? Bool {
             self.isRunFirstTime = value
         } else {
             self.isRunFirstTime = true
         }
-        self.isLoggingOvertime = defaults.bool(forKey: SettingKey.isLoggingOvertime.rawValue)
-        self.isCalculatingNetPay = defaults.bool(forKey: SettingKey.isCalculatingNetPay.rawValue)
-        self.isSendingNotification = defaults.bool(forKey: SettingKey.isSendingNotifications.rawValue)
-        self.maximumOvertimeAllowedInSeconds = defaults.integer(
-            forKey: SettingKey.maximumOvertimeAllowedInSeconds.rawValue
-        )
-        self.workTimeInSeconds = defaults.integer(forKey: SettingKey.workTimeInSeconds.rawValue)
-        self.grossPayPerMonth = defaults.integer(
-            forKey: SettingKey.grossPayPerMonth.rawValue
-        )
+        loadValuesFromDefaults()
         self.setUpSubscribersSavingToUserDefaults()
     }
     
-    private func setUpSubscribersSavingToUserDefaults() {
-        logger.debug("setUpSubscribers called")
-        
-        boolPublishersWithKeys
-            .forEach { key, publisher in
-                publisher
-                    .dropFirst()
-                    .removeDuplicates()
-                    .sink { [weak self] value in
-                        self?.updateSetting(setting: key, value: value)
-                    }.store(in: &subscriptions)
-        }
-        
-        intPublishersWithKeys
-            .forEach { key, publisher in
-                publisher
-                    .dropFirst()
-                    .removeDuplicates()
-                    .sink { [weak self] value in
-                        self?.updateSetting(setting: key, value: value)
-                    }.store(in: &subscriptions)
-        }
-    }
     
     public func clearStore() {
         logger.debug("clearStore called")
@@ -86,54 +53,7 @@ public final class SettingsStore: ObservableObject, SettingsStoring, TestDefault
                 updateSetting(setting: key, value: false)
             }
         }
-        isLoggingOvertime = defaults.bool(forKey: SettingKey.isLoggingOvertime.rawValue)
-        isCalculatingNetPay = defaults.bool(forKey: SettingKey.isCalculatingNetPay.rawValue)
-        isSendingNotification = defaults.bool(forKey: SettingKey.isSendingNotifications.rawValue)
-        maximumOvertimeAllowedInSeconds = defaults.integer(forKey: SettingKey.maximumOvertimeAllowedInSeconds.rawValue)
-        workTimeInSeconds = defaults.integer(forKey: SettingKey.workTimeInSeconds.rawValue)
-        grossPayPerMonth = defaults.integer(forKey: SettingKey.grossPayPerMonth.rawValue)
+        loadValuesFromDefaults()
         setUpSubscribersSavingToUserDefaults()
-    }
-    
-    public static func clearUserDefaults() {
-        Logger.settingsStore.debug("clearUserDefaults called")
-        for key in SettingKey.allCases {
-            UserDefaults.standard.removeObject(forKey: key.rawValue)
-        }
-    }
-    
-    public static func setTestUserDefaults() {
-        Logger.settingsStore.debug("setTestUserDefaults called")
-        let defaults = UserDefaults.standard
-        defaults.set(false, forKey: SettingKey.isRunFirstTime.rawValue)
-        defaults.set(true, forKey: SettingKey.isLoggingOvertime.rawValue)
-        defaults.set(true, forKey: SettingKey.isCalculatingNetPay.rawValue)
-        defaults.set(false, forKey: SettingKey.isSendingNotifications.rawValue)
-        defaults.set(28800, forKey: SettingKey.workTimeInSeconds.rawValue)
-        defaults.set(14400, forKey: SettingKey.maximumOvertimeAllowedInSeconds.rawValue)
-        defaults.set(10000, forKey: SettingKey.grossPayPerMonth.rawValue)
-    }
-    
-    private func updateSetting<T>(setting: SettingKey, value: T) {
-        logger.debug("updateSetting called for key: \(setting.rawValue)")
-        defaults.set(value, forKey: setting.rawValue)
-    }
-}
-
-extension SettingsStore {
-    var boolPublishersWithKeys: [SettingKey: Published<Bool>.Publisher] {
-        [
-            .isRunFirstTime: $isRunFirstTime,
-            .isLoggingOvertime: $isLoggingOvertime,
-            .isCalculatingNetPay: $isCalculatingNetPay,
-            .isSendingNotifications: $isSendingNotification
-        ]
-    }
-    var intPublishersWithKeys: [SettingKey: Published<Int>.Publisher] {
-        [
-            .maximumOvertimeAllowedInSeconds: $maximumOvertimeAllowedInSeconds,
-            .workTimeInSeconds: $workTimeInSeconds,
-            .grossPayPerMonth: $grossPayPerMonth
-        ]
     }
 }

--- a/Services/Sources/SettingsServiceInterfaces/SettingsStoring.swift
+++ b/Services/Sources/SettingsServiceInterfaces/SettingsStoring.swift
@@ -16,6 +16,8 @@ public protocol SettingsStoring: AnyObject, ObservableObject where ObjectWillCha
     var maximumOvertimeAllowedInSecondsPublisher: Published<Int>.Publisher { get }
     var workTimeInSecondsPublisher: Published<Int>.Publisher { get }
     var grossPayPerMonthPublisher: Published<Int>.Publisher { get }
+    
+    func clearStore()
 }
 
 public protocol TestDefaultsSetting {

--- a/Services/Sources/SettingsServiceMocks/MockSettingsService.swift
+++ b/Services/Sources/SettingsServiceMocks/MockSettingsService.swift
@@ -18,13 +18,41 @@ public final class MockSettingsService: ObservableObject, SettingsStoring {
     @Published public var workTimeInSeconds: Int
     @Published public var grossPayPerMonth: Int
 
-    public init() {
-        self.isRunFirstTime = false
-        self.isLoggingOvertime = true
-        self.isCalculatingNetPay = true
-        self.isSendingNotification = false
-        self.workTimeInSeconds = 28800
-        self.maximumOvertimeAllowedInSeconds = 14400
-        self.grossPayPerMonth = 10000
+    /// Initialize with default testing values
+    public convenience init() {
+        self.init(isRunFirstTime: false,
+                  isLoggingOvertime: true,
+                  isCalculatingNetPay: true,
+                  isSendingNotification: false,
+                  maximumOvertimeAllowedInSeconds: 28800,
+                  workTimeInSeconds: 14400,
+                  grossPayPerMonth: 10000)
     }
+    
+    public init(isRunFirstTime: Bool,
+                isLoggingOvertime: Bool,
+                isCalculatingNetPay: Bool,
+                isSendingNotification: Bool,
+                maximumOvertimeAllowedInSeconds: Int,
+                workTimeInSeconds: Int,
+                grossPayPerMonth: Int) {
+        self.isRunFirstTime = isRunFirstTime
+        self.isLoggingOvertime = isLoggingOvertime
+        self.isCalculatingNetPay = isCalculatingNetPay
+        self.isSendingNotification = isSendingNotification
+        self.maximumOvertimeAllowedInSeconds = maximumOvertimeAllowedInSeconds
+        self.workTimeInSeconds = workTimeInSeconds
+        self.grossPayPerMonth = grossPayPerMonth
+    }
+    
+    public func clearStore() {
+        isRunFirstTime = false
+        isLoggingOvertime = false
+        isCalculatingNetPay = false
+        isSendingNotification = false
+        maximumOvertimeAllowedInSeconds = 0
+        workTimeInSeconds = 0
+        grossPayPerMonth = 0
+    }
+    
 }

--- a/Services/Sources/SettingsServiceMocks/MockSettingsService.swift
+++ b/Services/Sources/SettingsServiceMocks/MockSettingsService.swift
@@ -1,6 +1,5 @@
 import Combine
 import SettingsServiceInterfaces
-import SwiftUI // TODO: Remove color scheme
 
 public final class MockSettingsService: ObservableObject, SettingsStoring {
     public var isRunFirstTimePublisher: Published<Bool>.Publisher { $isRunFirstTime }
@@ -18,7 +17,6 @@ public final class MockSettingsService: ObservableObject, SettingsStoring {
     @Published public var maximumOvertimeAllowedInSeconds: Int
     @Published public var workTimeInSeconds: Int
     @Published public var grossPayPerMonth: Int
-    @Published public var savedColorScheme: ColorScheme?
 
     public init() {
         self.isRunFirstTime = false
@@ -28,6 +26,5 @@ public final class MockSettingsService: ObservableObject, SettingsStoring {
         self.workTimeInSeconds = 28800
         self.maximumOvertimeAllowedInSeconds = 14400
         self.grossPayPerMonth = 10000
-        self.savedColorScheme = nil
     }
 }


### PR DESCRIPTION
# Why was the change needed? 
Unused color scheme setting should be removed. It brings unneccessary SwiftUI imports.

# What was done?
- Remove color scheme setting
- Refactor settings store
